### PR TITLE
Update `log` binding for renamed type in Maven nightly

### DIFF
--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -5,7 +5,7 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.monitor.logging.DefaultLog;
+import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.logging.Logger;
 
 import java.io.File;
@@ -43,11 +43,91 @@ final class GroovyScriptUserData {
         binding.setVariable("gradleEnterprise", gradleEnterprise);
         binding.setVariable("buildScan", gradleEnterprise.getBuildScan());
         binding.setVariable("buildCache", gradleEnterprise.getBuildCache());
-        binding.setVariable("log", new DefaultLog(logger));
+        binding.setVariable("log", new MavenLogger(logger));
         return binding;
     }
 
     private GroovyScriptUserData() {
+    }
+
+    /**
+     * Since there's no consistent implementation type across different versions of Maven,
+     * we use an internal implementation of Maven {@link Log} that wraps the Plexus {@link Logger}.
+     */
+    private static final class MavenLogger implements Log {
+        private final Logger plexusLogger;
+
+        private MavenLogger(Logger plexusLogger) {
+            this.plexusLogger = plexusLogger;
+        }
+
+        public void debug(CharSequence content) {
+            plexusLogger.debug(toString(content));
+        }
+
+        private String toString(CharSequence content) {
+            return content == null ? "" : content.toString();
+        }
+
+        public void debug(CharSequence content, Throwable error) {
+            plexusLogger.debug(toString(content), error);
+        }
+
+        public void debug(Throwable error) {
+            plexusLogger.debug("", error);
+        }
+
+        public void info(CharSequence content) {
+            plexusLogger.info(toString(content));
+        }
+
+        public void info(CharSequence content, Throwable error) {
+            plexusLogger.info(toString(content), error);
+        }
+
+        public void info(Throwable error) {
+            plexusLogger.info("", error);
+        }
+
+        public void warn(CharSequence content) {
+            plexusLogger.warn(toString(content));
+        }
+
+        public void warn(CharSequence content, Throwable error) {
+            plexusLogger.warn(toString(content), error);
+        }
+
+        public void warn(Throwable error) {
+            plexusLogger.warn("", error);
+        }
+
+        public void error(CharSequence content) {
+            plexusLogger.error(toString(content));
+        }
+
+        public void error(CharSequence content, Throwable error) {
+            plexusLogger.error(toString(content), error);
+        }
+
+        public void error(Throwable error) {
+            plexusLogger.error("", error);
+        }
+
+        public boolean isDebugEnabled() {
+            return plexusLogger.isDebugEnabled();
+        }
+
+        public boolean isInfoEnabled() {
+            return plexusLogger.isInfoEnabled();
+        }
+
+        public boolean isWarnEnabled() {
+            return plexusLogger.isWarnEnabled();
+        }
+
+        public boolean isErrorEnabled() {
+            return plexusLogger.isErrorEnabled();
+        }
     }
 
 }


### PR DESCRIPTION
We previously used `org.apache.maven.monitor.logging.DefaultLog` to wrap
a Plexus `Logger` instance as a `org.apache.maven.plugin.logging.Log` type.
This type has been renamed in the latest Maven nightly, so we now provide
a custom wrapper implementation instead.

This is a quick-fix to ensure the CCUDME functions with all supported versions
of Maven. A better solution might be to provide a SLF4J logger to Groovy
scripts rather than `org.apache.maven.plugin.logging.Log`.