### PR TITLE
Add a script to find the unique git repositories via the Develocity API

### DIFF
--- a/git-user-count/README.md
+++ b/git-user-count/README.md
@@ -1,8 +1,24 @@
-## Develocity Git User Count
+# Develocity Git User Count
 
-### Overview
+## Overview
 
-The Develocity Git user count script provides a means to automate the counting of the number of unique active developers in separate Git repositories.
+There are two scripts in this repository. 
+The first script `unique-git-repos.sh` provides a means to gather a list of unique git repositories publishing scans to a Develocity instance.
+The second script `user-count.sh` provides a means to automate the counting of the number of unique active developers in separate git repositories.
+
+## Unique Git Repositories
+
+The Develocity configuration must be configured to publish a custom value with the key `Git repository` to Develocity. This can be done automatically via the Common Custom User Data Gradle plugin or Maven extension.
+
+### Usage
+
+1. Run the `./unique-git-repos.sh` bash script. The script supports the following ordered command line arguments:
+    * `<develocity-url>`: The URL of the Develocity instance.
+    * `<access-key>`: The access token to use when connecting to the Develocity instance.
+    * `<days>`: Number of days to go back in history (default: 7).
+2. The script will output a list of unique git repositories to `repositories.txt`.
+
+## Git User Count
 
 ### Usage
 
@@ -21,4 +37,3 @@ The Develocity Git user count script provides a means to automate the counting o
 The `user-count.sh` script reads the list of Git repositories from the `repositories.txt` file.
 The script creates a temporary folder and clones the listed Git repositories to that folder in a minimal state.
 It then writes all the unique emails committed to that repository to a file named `develocity-unique-users.txt`.
-

--- a/git-user-count/unique-git-repos.sh
+++ b/git-user-count/unique-git-repos.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Command line options for GRADLE_ENTERPRISE_URL and ACCESS_KEY
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 <gradle_enterprise_url> <access_key> [number_of_days]"
+    exit 1
+fi
+
+GRADLE_ENTERPRISE_URL="$1"
+ACCESS_KEY="$2"
+NUMBER_OF_DAYS="${3:-7}" # Default to 7 days if not provided
+FROM_INSTANT=$(date -d "$NUMBER_OF_DAYS days ago" +%s)000  # Days ago in milliseconds
+
+# Function to fetch builds
+fetch_builds() {
+    local from_build=$1
+    local url="$GRADLE_ENTERPRISE_URL/api/builds?models=gradle-attributes&models=maven-attributes&fromInstant=$FROM_INSTANT&maxBuilds=1000"
+    if [[ -n "$from_build" ]]; then
+        url="$url&fromBuild=$from_build"
+    fi
+    curl -s -H "Authorization: Bearer $ACCESS_KEY" -H "Content-Type: application/json" "$url"
+}
+
+# Main loop to fetch all builds with pagination and extract Git repositories
+git_repos=()
+from_build=""
+while :; do
+    response=$(fetch_builds "$from_build")
+    num_builds=$(echo "$response" | jq -r '. | length')
+
+    # Progress message
+    echo "Fetched $num_builds builds"
+    
+    # Extract Git repository values
+    new_repos=$(echo "$response" | jq -r '.[] | .models.gradleAttributes.model.values[]?, .models.mavenAttributes.model.values[]? | select(.name=="Git repository").value // empty')
+    git_repos+=("$new_repos")
+
+    if [[ num_builds -eq 0 || num_builds -lt 1000 ]]; then
+        break  # No more builds to fetch or fewer than 1000 builds
+    fi
+
+    from_build=$(echo "$response" | jq -r '.[-1].id')  # Set fromBuild for the next request
+done
+
+# Remove duplicates and count unique Git repositories
+unique_git_repos=($(echo "${git_repos[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+num_unique_repos=${#unique_git_repos[@]}
+
+# Print unique Git repositories and their count
+echo "Number of unique Git repositories: $num_unique_repos"
+printf "%s\n" "${unique_git_repos[@]}" > repositories.txt
+echo "List of unique Git repositories saved to repositories.txt"

--- a/git-user-count/unique-git-repos.sh
+++ b/git-user-count/unique-git-repos.sh
@@ -43,7 +43,7 @@ while :; do
 done
 
 # Remove duplicates and count unique Git repositories
-unique_git_repos=($(echo "${git_repos[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+IFS=$'\n' read -r -d '' -a unique_git_repos < <(printf "%s\n" "${git_repos[@]}" | sort -u && printf '\0')
 num_unique_repos=${#unique_git_repos[@]}
 
 # Print unique Git repositories and their count


### PR DESCRIPTION
Instructions on how to use this are in the updated README.

As for performance, it is much faster by combining requests with the new models API.
Fetching 1 days of builds from ge.solutions-team.gradle.com in batches of 1000 took
366 seconds via [the gist](https://gist.github.com/jprinet/13ffaac26a973cd20c37007e93f0a67c).
18 seconds via this script.

