### PR TITLE
Added `formats` as an iterated tracked property when caching the Spotless plugin

### DIFF
--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -78,9 +78,6 @@
                                                 <name>filePatterns</name>
                                             </property>
                                             <property>
-                                                <name>formats</name>
-                                            </property>
-                                            <property>
                                                 <name>goal</name>
                                             </property>
                                             <property>

--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -25,6 +25,14 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <formats>
+                        <format>
+                            <includes>
+                                <include>src/main/**/package-info.java</include>
+                                <include>src/main/**/module-info.java</include>
+                            </includes>
+                        </format>
+                    </formats>
                     <java>
                         <includes>
                             <include>src/main/java/**/*.java</include>

--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -100,6 +100,30 @@
                                             <ignore>lineEndings</ignore>
                                         </ignoredProperties>
                                     </inputs>
+                                    <iteratedProperties>
+                                        <property>
+                                            <name>formats</name>
+                                            <inputs>
+                                                <properties>
+                                                    <property>
+                                                        <name>encoding</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>lineEndings</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>ratchetFrom</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>includes</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>excludes</name>
+                                                    </property>
+                                                </properties>
+                                            </inputs>
+                                        </property>
+                                    </iteratedProperties>
                                     <nestedProperties>
                                         <property>
                                             <name>licenseHeader</name>


### PR DESCRIPTION
Added `formats` as an iterated tracked property when caching the Spotless plugin. 

Without this change customers will see a message: [Build caching was not enabled for this goal execution because property 'formats' contains unsupported type: Format](https://ge.solutions-team.gradle.com/s/7s67jzuijtbdk/timeline?details=thu2a7izgw4gq&hide-timeline&outcome=success&view=by-type), if they define `<formats>` in the spotless configuration, for example in [micronaut-maven-plugin](https://github.com/micronaut-projects/micronaut-maven-plugin/blob/8c064b8a0f2fb3794bba0ef0bf14908b423e7a21/pom.xml#L359-L370) project. 

With this change, spotless plugin caching works correctly, [detecting changes](https://ge.solutions-team.gradle.com/c/ex53xs5g7efak/32dx2cuguz3ue/goal-inputs?expanded=WyJ0aHUyYTdpemd3NGdxLWJhc2VkaXIiLCJ0aHUyYTdpemd3NGdxLWJhc2VEaXItMC0wIl0#thu2a7izgw4gq-formats.0.includes) in the `formats` configuration, even if inherited from a parent project.