### PR TITLE
Migrate Gradle samples to use new DV API

### DIFF
--- a/common-develocity-gradle-configuration-groovy/settings.gradle
+++ b/common-develocity-gradle-configuration-groovy/settings.gradle
@@ -1,18 +1,16 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.17'
+    id 'com.gradle.develocity' version '3.17'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2'
 }
 
 def isCI = System.getenv('CI') != null // adjust to your CI provider
 
-gradleEnterprise {
+develocity {
     server = 'https://develocity-samples.gradle.com' // adjust to your Develocity server
     allowUntrustedServer = false // ensure a trusted certificate is configured
 
     buildScan {
-        capture { taskInputFiles = true }
         uploadInBackground = !isCI
-        publishAlways()
     }
 }
 
@@ -21,7 +19,7 @@ buildCache {
         enabled = true
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         enabled = true
         push = isCI
     }

--- a/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
+++ b/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
@@ -1,18 +1,16 @@
 plugins {
-    id("com.gradle.enterprise") version "3.17"
+    id("com.gradle.develocity") version "3.17"
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2"
 }
 
 val isCI = !System.getenv("CI").isNullOrEmpty() // adjust to your CI provider
 
-gradleEnterprise {
+develocity {
     server = "https://develocity-samples.gradle.com" // adjust to your Develocity server
     allowUntrustedServer = false // ensure a trusted certificate is configured
 
     buildScan {
-        capture { isTaskInputFiles = true }
-        isUploadInBackground = !isCI
-        publishAlways()
+        uploadInBackground = !isCI
     }
 }
 
@@ -21,7 +19,7 @@ buildCache {
         isEnabled = true
     }
 
-    remote(gradleEnterprise.buildCache) {
+    remote(develocity.buildCache) {
         isEnabled = true
         isPush = isCI
     }

--- a/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/settings.gradle
+++ b/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.17'
+    id 'com.gradle.develocity' version '3.17'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }

--- a/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/settings.gradle
+++ b/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.17'
+    id 'com.gradle.develocity' version '3.17'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }


### PR DESCRIPTION
The samples were previously intentionally verbose. Given the new defaults for always publishing scans and always capturing input files, I think that we can simplify the configuration and reduce verbosity. Open to having a discussion about this.