### PR TITLE
Use 1.0 versions of sbt develocity plugin and ccud

### DIFF
--- a/common-develocity-sbt-configuration/build.sbt
+++ b/common-develocity-sbt-configuration/build.sbt
@@ -1,13 +1,12 @@
 // You can configure the Develocity sbt plugin to publish Build Scans to your Develocity server
 // by adding the following configuration to your project's build.sbt file
 
-Global / gradleEnterpriseConfiguration :=
-  GradleEnterpriseConfiguration(
+Global / develocityConfiguration :=
+  DevelocityConfiguration(
     server = Server(
       url = Some(url("https://develocity-samples.gradle.com")), // adjust to your Develocity server
       allowUntrusted = false), // ensure a trusted certificate is configured
     buildScan = BuildScan(
-      publishConfig = PublishConfig.Always,
       backgroundUpload = !sys.env.get("CI").exists(_.toBoolean)))
 
 lazy val `common-develocity-sbt-configuration` = (project in file(".")) // adjust to your project name

--- a/common-develocity-sbt-configuration/build.sbt
+++ b/common-develocity-sbt-configuration/build.sbt
@@ -1,7 +1,7 @@
 // You can configure the Develocity sbt plugin to publish Build Scans to your Develocity server
 // by adding the following configuration to your project's build.sbt file
 
-Global / develocityConfiguration :=
+ThisBuild / develocityConfiguration :=
   DevelocityConfiguration(
     server = Server(
       url = Some(url("https://develocity-samples.gradle.com")), // adjust to your Develocity server

--- a/common-develocity-sbt-configuration/project/build.properties
+++ b/common-develocity-sbt-configuration/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/common-develocity-sbt-configuration/project/plugins.sbt
+++ b/common-develocity-sbt-configuration/project/plugins.sbt
@@ -1,4 +1,5 @@
 // You apply the Develocity sbt plugin to your build by adding the following
 // configuration block to a new or existing project/plugins.sbt file in your sbt project
 
-addSbtPlugin("com.gradle" % "sbt-gradle-enterprise" % "0.10.1")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.0")
+addSbtPlugin("com.gradle" % "sbt-develocity-common-custom-user-data" % "1.0")


### PR DESCRIPTION
This updates to the stable sbt DV plugin 1.0 and migrates the APIs.

This also moves the `plugins.sbt` folder to the `projects` directory since I was having compilation errors finding DV classes before moving it there.
This also applies the CCUD sbt plugin 1.0
