### PR TITLE
Support Quarkus 3.9 

### DIFF
--- a/quarkus-build-caching-extension/README.md
+++ b/quarkus-build-caching-extension/README.md
@@ -38,7 +38,7 @@ Reference the extension in `.mvn/extensions.xml` (this extension requires the de
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>quarkus-build-caching-extension</artifactId>
-        <version>1.0</version>
+        <version>1.1</version>
     </extension>
 </extensions>
 ```
@@ -47,7 +47,7 @@ Note on the Compatibility with The Develocity extension:
 
 | Extension                                      | Compatible version |
 |------------------------------------------------|--------------------|
-| `com.gradle:develocity-maven-extension`        | 1.0                |
+| `com.gradle:develocity-maven-extension`        | 1.+                |
 | `com.gradle:gradle-enterprise-maven-extension` | 0.12               |
 
 Enable [Quarkus config tracking](https://quarkus.io/guides/config-reference#dumping-build-time-configuration-options-read-during-the-build) in `pom.xml`:

--- a/quarkus-build-caching-extension/release/changes.md
+++ b/quarkus-build-caching-extension/release/changes.md
@@ -1,1 +1,10 @@
-- Add compatiblity with develocity-maven-extension:1.21
+### 1.1
+- Add support for Quarkus 3.9 (`quarkus.package.type` is replaced by `quarkus.native.enabled` / `quarkus.package.jar.type`)
+
+### 1.0
+- Add compatibility with `develocity-maven-extension:1.21`
+
+---
+
+### 0.12
+- First version


### PR DESCRIPTION
### Issue
The Quarkus build caching extension is not compatible with the most recent version of the Quarkus project (3.9+).
Something has changed with the package type since [this commit](https://github.com/quarkusio/quarkus/commit/095feab7314beef55520d4e5087daf053755260e).
The impact is noticeable on this [log entry](https://ge.quarkus.io/s/wtygunp4imvdy/console-log?page=1#L256)

### Fix
`quarkus.package.type` is replaced by `quarkus.native.enabled` / `quarkus.package.jar.type`
The check if the build is native or not will be run on both deprecated and non deprecated properties to ensure ascending compatibility.
