### PR TITLE
Fixed PTS script if not all dependencies are resolvable

### DIFF
--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -69,8 +69,13 @@ class Capture {
 
     boolean cucumberUsedWithoutCompanion(Test t) {
         def cucumberUsed = t.project.configurations.stream().filter { it.canBeResolved }.any {
-            it.resolvedConfiguration.resolvedArtifacts.any {
-                it.moduleVersion.id.group == 'io.cucumber'
+            try {
+                it.resolvedConfiguration.resolvedArtifacts.any {
+                    it.moduleVersion.id.group == "io.cucumber"
+                }
+            } catch (Exception e) {
+                logger.warn("WARN: Could not resolve ${it.name} -> Cucumber test detection might be incomplete!")
+                false
             }
         }
         return cucumberUsed && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion')

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -65,8 +65,13 @@ class Capture(val api: BuildScanExtension, val logger: Logger) {
 
     private fun cucumberUsedWithoutCompanion(t: Test): Boolean {
         val cucumberUsed = t.project.configurations.filter { it.isCanBeResolved }.any {
-            it.resolvedConfiguration.resolvedArtifacts.any {
-                it.moduleVersion.id.group == "io.cucumber"
+            try {
+                it.resolvedConfiguration.resolvedArtifacts.any {
+                    it.moduleVersion.id.group == "io.cucumber"
+                }
+            } catch (e: Exception) {
+                logger.warn("WARN: Could not resolve ${it.name} -> Cucumber test detection might be incomplete!")
+                false
             }
         }
         return cucumberUsed && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion")


### PR DESCRIPTION
If not all dependencies/configurations are resolvable, currently the PTS support detection script throws an [error that fails the build](https://ge.solutions-team.gradle.com/s/byyxejysywnd4/failure#1), even if the build otherwise succeeds.

With these changes, the [build will still pass](https://ge.solutions-team.gradle.com/s/uov4lngy6meii), but show a [warning about it being unable to resolve some of the configurations](https://ge.solutions-team.gradle.com/s/uov4lngy6meii/console-log?page=1#L13).