### PR TITLE
Kotlin `isCI` conditional is inconsistent with Groovy

### DIFF
--- a/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
+++ b/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.gradle.common-custom-user-data-gradle-plugin") version "2.0"
 }
 
-val isCI = !System.getenv("CI").isNullOrEmpty() // adjust to your CI provider
+val isCI = System.getenv("CI") != null // adjust to your CI provider
 
 develocity {
     server = "https://develocity-samples.gradle.com" // adjust to your Develocity server


### PR DESCRIPTION
The Kotlin CI conditional is inconsistent with [the Groovy sample](https://github.com/gradle/develocity-build-config-samples/blob/eb8bd221a42f90fce12dfcd72730dccab688a37c/common-develocity-gradle-configuration-groovy/settings.gradle#L6). The Kotlin sample checks that the environment variable "CI" exists *and* is valued (not empty). The Groovy sample only checks for the presence of the "CI" environment variable.

Just the presence of the "CI" environment variable should be good enough. If a user needs it to be more specific, they can adjust the conditional to their needs as the comment suggests.