### PR TITLE
Develocity Gradle plugin is removed from convention plugin sample

### DIFF
--- a/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/settings.gradle
+++ b/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/settings.gradle
@@ -1,6 +1,4 @@
 plugins {
-    id 'com.gradle.develocity' version '3.17.3'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 

--- a/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/settings.gradle
+++ b/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/settings.gradle
@@ -1,6 +1,4 @@
 plugins {
-    id 'com.gradle.develocity' version '3.17.3'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.1'
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
 }
 


### PR DESCRIPTION
As it exists today, the user is prompted to publish the scan to `scans.gradle.com`. This is because the Develocity Gradle plugin is applied, but not configured.

This change removes the Develocity Gradle and CCUD plugins.