### PR TITLE
Github actions access token migration

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v3
         with:
-          develocity-access-key: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          develocity-access-key: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Inject data capture script into Gradle build using Groovy DSL
         working-directory: common-develocity-gradle-configuration-groovy
         run: |

--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -42,6 +42,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v3
+        with:
+          develocity-access-key: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
       - name: Inject data capture script into Gradle build using Groovy DSL
         working-directory: common-develocity-gradle-configuration-groovy
         run: |
@@ -49,9 +51,7 @@ jobs:
           echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> build.gradle
       - name: Run Gradle build using Groovy DSL
         working-directory: common-develocity-gradle-configuration-groovy
-        run: ./gradlew tasks -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+        run: ./gradlew tasks -Ddevelocity.url=https://ge.solutions-team.gradle.com
       - name: Inject data capture script into Gradle build using Kotlin DSL
         working-directory: common-develocity-gradle-configuration-kotlin
         run: |
@@ -59,6 +59,4 @@ jobs:
           echo "apply(from = \"../build-data-capturing-gradle-samples/${{matrix.sample-file}}.kts\")" >> build.gradle.kts
       - name: Run Gradle build using Kotlin DSL
         working-directory: common-develocity-gradle-configuration-kotlin
-        run: ./gradlew tasks -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+        run: ./gradlew tasks -Ddevelocity.url=https://ge.solutions-team.gradle.com

--- a/.github/workflows/maven-build-caching-samples-verification.yml.disabled
+++ b/.github/workflows/maven-build-caching-samples-verification.yml.disabled
@@ -41,7 +41,7 @@ jobs:
             -f -e 2>&1 | tee -a /tmp/build.log
           echo "hasUnknownParams=$(grep "Build caching was not enabled for this goal execution because the following parameters were not handled" /tmp/build.log | wc -l)" >> $GITHUB_OUTPUT
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify no unmapped mojo parameters
         if: (success() || failure()) && steps.build.outputs.hasUnknownParams != '0'
         run: exit 1

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -51,7 +51,7 @@ jobs:
           echo "$(mvn -f common-develocity-maven-configuration/pom.xml -Ddevelocity.url=https://ge.solutions-team.gradle.com -X -B clean validate)" >> $GITHUB_OUTPUT
           echo "${delimiter}" >> $GITHUB_OUTPUT
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Validate extension loaded
         # Asserting that extension was loaded checking a log entry
         run: exit 1

--- a/.github/workflows/quarkus-build-caching-extension.yml
+++ b/.github/workflows/quarkus-build-caching-extension.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           ./mvnw --batch-mode clean package integration-test
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Upload integration tests reports (on failure only)
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Migrated GitHub actions gradle executions to access token auth 
- Migrated GitHub actions maven executions env var access key to develocity naming
- Replaced cmdline setting of dv server to develocity naming in github actions (`-Ddevelocity.url=<url>`)