### PR TITLE
Add quarkus-artifact.properties as an output of quarkus:build

### DIFF
--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
@@ -47,6 +47,10 @@ final class QuarkusBuildCache {
     // Quarkus' properties which should be ignored (the JDK / GraalVM version are extra inputs)
     private static final List<String> QUARKUS_IGNORED_PROPERTIES = Arrays.asList(QUARKUS_CONFIG_KEY_GRAALVM_HOME, QUARKUS_CONFIG_KEY_JAVA_HOME);
 
+    // this file contains some metadata required for running the Failsafe tests
+    // it also contains the full GraalVM version
+    private static final String QUARKUS_ARTIFACT_PROPERTIES_FILE_NAME = "target/quarkus-artifact.properties";
+
     void configureBuildCache(BuildCacheApi buildCache) {
         buildCache.registerNormalizationProvider(context -> {
             QuarkusExtensionConfiguration extensionConfiguration = new QuarkusExtensionConfiguration(context.getProject());
@@ -63,6 +67,7 @@ final class QuarkusBuildCache {
             });
             context.withPlugin("maven-failsafe-plugin", () -> {
                 configureQuarkusExtraTestInputs(context, extensionConfiguration);
+                context.inputs(inputs -> addQuarkusArtifactPropertiesInput(inputs, extensionConfiguration));
             });
         });
     }
@@ -264,6 +269,10 @@ final class QuarkusBuildCache {
         inputs.fileSet("quarkusDependencyChecksums", new File(extensionConfiguration.getCurrentDependencyChecksumsFileName()), fileSet -> fileSet.normalizationStrategy(MojoMetadataProvider.Context.FileSet.NormalizationStrategy.RELATIVE_PATH));
     }
 
+    private void addQuarkusArtifactPropertiesInput(MojoMetadataProvider.Context.Inputs inputs, QuarkusExtensionConfiguration extensionConfiguration) {
+        inputs.fileSet("quarkusArtifactProperties", new File(QUARKUS_ARTIFACT_PROPERTIES_FILE_NAME), fileSet -> fileSet.normalizationStrategy(MojoMetadataProvider.Context.FileSet.NormalizationStrategy.RELATIVE_PATH));
+    }
+
     private void addQuarkusDependenciesInputs(MojoMetadataProvider.Context.Inputs inputs, QuarkusExtensionConfiguration extensionConfiguration) {
         File quarkusDependencyFile = new File(extensionConfiguration.getCurrentDependencyFileName());
         if (quarkusDependencyFile.exists()) {
@@ -288,6 +297,7 @@ final class QuarkusBuildCache {
             outputs.file("quarkusExe", quarkusExeFileName);
             outputs.file("quarkusJar", quarkusJarFileName);
             outputs.file("quarkusUberJar", quarkusUberJarFileName);
+            outputs.file("quarkusArtifactProperties", QUARKUS_ARTIFACT_PROPERTIES_FILE_NAME);
         });
     }
 

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
@@ -67,7 +67,8 @@ final class QuarkusBuildCache {
             });
             context.withPlugin("maven-failsafe-plugin", () -> {
                 configureQuarkusExtraTestInputs(context, extensionConfiguration);
-                context.inputs(inputs -> addQuarkusArtifactPropertiesInput(inputs, extensionConfiguration));
+                // For now, we don't add this one as an input but it might be a good idea to add it in the future
+                //context.inputs(inputs -> addQuarkusArtifactPropertiesInput(inputs, extensionConfiguration));
             });
         });
     }


### PR DESCRIPTION
Since the cache for quarkus:build has been fixed in the Quarkus CI, we are starting to see failures because the `target/quarkus-artifact.properties` is missing. This is because it's not part of the cache so whenever we have a cache hit, it's not restored.

----

When running ITs for native, we need quarkus-artifact.properties to be around so it needs to be part of the cache.

Also make it an input of Failsafe.
This file contains a relative path to the binary to run and a few additional metadata such as the full GraalVM version. Whenever this version has changed, we need to run the tests again so it makes sense to make it an input.

Note that we will need https://github.com/quarkusio/quarkus/pull/41587 to be in so that quarkus-artifact.properties doesn't contain a timestamp.