### PR TITLE
Add configuration options for the quarkus-build-caching-extension

### DIFF
--- a/quarkus-build-caching-extension/README.md
+++ b/quarkus-build-caching-extension/README.md
@@ -9,20 +9,26 @@ A native executable can be a very large file. Copying it from/to the local cache
 ## Requirements
 Quarkus 3.2.4 and above which brings [track-config-changes goal](https://quarkus.io/guides/config-reference#tracking-build-time-configuration-changes-between-builds)
 
-*Note:*<br>
-Although Quarkus 3.2.4 is required, 3.9.0 and above is recommended as it exposes [Quarkus extra dependencies](#quarkus-extra-dependencies) which is added as extra input by the current extension. 
+> [!NOTE]  
+> Although Quarkus 3.2.4 is required, 3.9.0 and above is recommended as it exposes [Quarkus extra dependencies](#quarkus-extra-dependencies) which is added as extra input by the current extension. 
 
 This additional input is necessary when using snapshot versions (or when overwriting fixed version) of
 - The Quarkus dependencies
 - A custom Quarkus extension 
 
 ## Limitations
-- Only the `native`, `uber-jar`, `jar` and `legacy-jar` [packaging types](https://quarkus.io/guides/maven-tooling#quarkus-package-pkg-package-config_quarkus.package.type) can be made cacheable
-- The `native` packaging is cacheable only if the in-container build strategy (`quarkus.native.container-build=true`) is configured along with a fixed build image (`quarkus.native.builder-image`).
 
-**Note:**<br>
-- When the in-container build strategy is used as a fallback the caching feature will be disabled. The fallback may happen due to GraalVM requirements not met. The recommendation is to explicitly set the in-container strategy (`quarkus.native.container-build=true`) to benefit from caching
-- The in-container build strategy means the build is as reproducible as possible. Even so, some timestamps and instruction ordering may be different even when built on the same system in the same environment.
+### Supported package types
+Only the `native`, `uber-jar`, `jar` and `legacy-jar` [packaging types](https://quarkus.io/guides/maven-tooling#quarkus-package-pkg-package-config_quarkus.package.type) can be made cacheable
+
+### Build strategy
+By default, the `native` packaging is cacheable only if the in-container build strategy (`quarkus.native.container-build=true`) is configured along with a fixed build image (`quarkus.native.builder-image`).
+The in-container build strategy means the build is as reproducible as possible. Even so, some timestamps and instruction ordering may be different even when built on the same system in the same environment.
+
+If the build environments are strictly identical, this restriction can be removed by setting `DEVELOCITY_QUARKUS_NATIVE_BUILD_IN_CONTAINER_REQUIRED=false`. See [configuration section](#build-strategy-1) for more details.
+
+> [!NOTE]
+> When the in-container build strategy is used as a fallback the caching feature will be disabled. The fallback may happen due to GraalVM requirements not met. The recommendation is to explicitly set the in-container strategy (`quarkus.native.container-build=true`) to benefit from caching
 
 ## Usage
 
@@ -98,12 +104,22 @@ It is also possible to have different Maven profiles with specific file suffixes
 
 ## Configuration
 
+Configuration can be set with (listed in order of precedence ):
+- [Environment variables](#environment-variables)
+- [Maven properties](#maven-properties)
+- [Configuration file](#configuration-file)
+
 ### Environment variables
 
-The caching can be disabled by setting an environment variable:
+#### Feature toggle
+
+The caching can be disabled by setting:
 ```properties
 DEVELOCITY_QUARKUS_CACHE_ENABLED=false
 ```
+
+#### Quarkus configuration dump
+
 By default, the values below are used to compute the dump-config (`.quarkus/quarkus-prod-config-dump`) and
 config-check (`target/quarkus-prod-config-check`) file names:
 - _build profile_: prod
@@ -117,7 +133,9 @@ DEVELOCITY_QUARKUS_DUMP_CONFIG_PREFIX=quarkus
 DEVELOCITY_QUARKUS_DUMP_CONFIG_SUFFIX=config-dump-ci
 ```
 
-Some additional outputs can be configured if necessary (if using the [quarkus-helm](https://quarkus.io/blog/quarkus-helm/#getting-started-with-the-quarkus-helm-extension) extension for instance). The path are relative to the `target` folder.
+#### Extra outputs
+
+Some additional outputs can be configured if necessary (when using the [quarkus-helm](https://quarkus.io/blog/quarkus-helm/#getting-started-with-the-quarkus-helm-extension) extension for instance). The paths are relative to the `target` folder.
 
 Directories can be added (csv list):
 ```properties
@@ -126,6 +144,14 @@ DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS=helm
 or Specific files (csv list):
 ```properties
 DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES=helm/kubernetes/my-project/Chart.yaml,helm/kubernetes/my-project/values.yaml
+```
+
+#### Build strategy
+
+The default is to enable caching only when the in-container build strategy is used. 
+If the build environments are strictly identical build over build, the restriction can be removed by setting:
+```properties
+DEVELOCITY_QUARKUS_NATIVE_BUILD_IN_CONTAINER_REQUIRED=false
 ```
 
 ### Maven properties
@@ -139,6 +165,7 @@ The same configuration can be achieved with Maven properties:
     <develocity.quarkus.dump.config.suffix>prod</develocity.quarkus.dump.config.suffix>
     <develocity.quarkus.extra.output.dirs>helm</develocity.quarkus.extra.output.dirs>
     <develocity.quarkus.extra.output.files>helm/kubernetes/${project.artifactId}/Chart.yaml,helm/kubernetes/${project.artifactId}/values.yaml</develocity.quarkus.extra.output.files>
+    <develocity.quarkus.native.build.in.container.required>false</develocity.quarkus.native.build.in.container.required>
 </properties>
 ```
 
@@ -266,6 +293,9 @@ Here are the files added as output:
 - `target/<project.build.finalName>.jar`
 - `target/<project.build.finalName>-runner.jar`
 - `target/quarkus-artifact.properties`
+
+> [!NOTE]
+> Some additional outputs can be configured. See the [configuration section](#extra-outputs) for more details.
 
 ## Quarkus Test goals
 

--- a/quarkus-build-caching-extension/README.md
+++ b/quarkus-build-caching-extension/README.md
@@ -117,15 +117,28 @@ DEVELOCITY_QUARKUS_DUMP_CONFIG_PREFIX=quarkus
 DEVELOCITY_QUARKUS_DUMP_CONFIG_SUFFIX=config-dump-ci
 ```
 
+Some additional outputs can be configured if necessary (if using the [quarkus-helm](https://quarkus.io/blog/quarkus-helm/#getting-started-with-the-quarkus-helm-extension) extension for instance). The path are relative to the `target` folder.
+
+Directories can be added (csv list):
+```properties
+DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS=helm
+```
+or Specific files (csv list):
+```properties
+DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES=helm/kubernetes/my-project/Chart.yaml,helm/kubernetes/my-project/values.yaml
+```
+
 ### Maven properties
 
 The same configuration can be achieved with Maven properties:
 ```xml
 <properties>
     <develocity.quarkus.cache.enabled>true</develocity.quarkus.cache.enabled>
-    <develocity.quarkus.build.profile>config-dump</develocity.quarkus.build.profile>
+    <develocity.quarkus.build.profile>config-dump-ci</develocity.quarkus.build.profile>
     <develocity.quarkus.dump.config.prefix>quarkus</develocity.quarkus.dump.config.prefix>
     <develocity.quarkus.dump.config.suffix>prod</develocity.quarkus.dump.config.suffix>
+    <develocity.quarkus.extra.output.dirs>helm</develocity.quarkus.extra.output.dirs>
+    <develocity.quarkus.extra.output.files>helm/kubernetes/${project.artifactId}/Chart.yaml,helm/kubernetes/${project.artifactId}/values.yaml</develocity.quarkus.extra.output.files>
 </properties>
 ```
 

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
@@ -125,7 +125,7 @@ final class QuarkusBuildCache {
                 if (isQuarkusBuildCacheable(quarkusPreviousProperties, quarkusCurrentProperties)) {
                     LOGGER.info(QuarkusExtensionUtil.getLogMessage("Quarkus build goal marked as cacheable"));
                     configureInputs(context, extensionConfiguration, quarkusCurrentProperties);
-                    configureOutputs(context);
+                    configureOutputs(context, extensionConfiguration.getExtraOutputDirs(), extensionConfiguration.getExtraOutputFiles());
                 } else {
                     LOGGER.info(QuarkusExtensionUtil.getLogMessage("Quarkus build goal marked as not cacheable"));
                 }
@@ -296,7 +296,7 @@ final class QuarkusBuildCache {
         }
     }
 
-    private void configureOutputs(MojoMetadataProvider.Context context) {
+    private void configureOutputs(MojoMetadataProvider.Context context, List<String> extraOutputDirs, List<String> extraOutputFiles) {
         context.outputs(outputs -> {
             String quarkusExeFileName = TARGET_DIR + context.getProject().getBuild().getFinalName() + "-runner";
             String quarkusJarFileName = TARGET_DIR + context.getProject().getBuild().getFinalName() + ".jar";
@@ -308,6 +308,20 @@ final class QuarkusBuildCache {
             outputs.file("quarkusJar", quarkusJarFileName);
             outputs.file("quarkusUberJar", quarkusUberJarFileName);
             outputs.file("quarkusArtifactProperties", quarkusArtifactProperties);
+
+            extraOutputDirs.forEach(extraOutput -> {
+                if(!extraOutput.isEmpty()) {
+                    LOGGER.debug(QuarkusExtensionUtil.getLogMessage("Adding extra output dir " + extraOutput));
+                    outputs.directory(extraOutput, TARGET_DIR + extraOutput);
+                }
+            });
+
+            extraOutputFiles.forEach(extraOutput -> {
+                if(!extraOutput.isEmpty()) {
+                    LOGGER.debug(QuarkusExtensionUtil.getLogMessage("Adding extra output file " + extraOutput));
+                    outputs.file(extraOutput, TARGET_DIR + extraOutput);
+                }
+            });
         });
     }
 

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Caching instructions for the Quarkus build goal.
@@ -123,7 +122,7 @@ final class QuarkusBuildCache {
                 Properties quarkusCurrentProperties = QuarkusExtensionUtil.loadProperties(baseDir, extensionConfiguration.getCurrentConfigFileName());
 
                 // Check required configuration
-                if (isQuarkusBuildCacheable(quarkusPreviousProperties, quarkusCurrentProperties, extensionConfiguration.getDumpConfigIgnoredProperties())) {
+                if (isQuarkusBuildCacheable(quarkusPreviousProperties, quarkusCurrentProperties)) {
                     LOGGER.info(QuarkusExtensionUtil.getLogMessage("Quarkus build goal marked as cacheable"));
                     configureInputs(context, extensionConfiguration, quarkusCurrentProperties);
                     configureOutputs(context);
@@ -136,11 +135,11 @@ final class QuarkusBuildCache {
         }
     }
 
-    private boolean isQuarkusBuildCacheable(Properties quarkusPreviousProperties, Properties quarkusCurrentProperties, List<String> dumpConfigIgnoredProperties) {
+    private boolean isQuarkusBuildCacheable(Properties quarkusPreviousProperties, Properties quarkusCurrentProperties) {
         return isQuarkusDumpConfigFilePresent(quarkusPreviousProperties, quarkusCurrentProperties)
                 && isJarPackagingTypeSupported(quarkusCurrentProperties)
                 && isNotNativeOrInContainerNativeBuild(quarkusCurrentProperties)
-                && isQuarkusPropertiesUnchanged(quarkusPreviousProperties, quarkusCurrentProperties, dumpConfigIgnoredProperties);
+                && isQuarkusPropertiesUnchanged(quarkusPreviousProperties, quarkusCurrentProperties);
     }
 
     private boolean isQuarkusDumpConfigFilePresent(Properties quarkusPreviousProperties, Properties quarkusCurrentProperties) {
@@ -156,14 +155,14 @@ final class QuarkusBuildCache {
         return true;
     }
 
-    private boolean isQuarkusPropertiesUnchanged(Properties quarkusPreviousProperties, Properties quarkusCurrentProperties, List<String> dumpConfigIgnoredProperties) {
+    private boolean isQuarkusPropertiesUnchanged(Properties quarkusPreviousProperties, Properties quarkusCurrentProperties) {
         Set<Map.Entry<Object, Object>> quarkusPropertiesCopy = new HashSet<>(quarkusPreviousProperties.entrySet());
 
         // Remove properties identical between current and previous build
         quarkusPropertiesCopy.removeAll(quarkusCurrentProperties.entrySet());
 
         // Remove properties which should be ignored
-        quarkusPropertiesCopy.removeIf(e -> getIgnoredProperties(dumpConfigIgnoredProperties).contains(e.getKey().toString()));
+        quarkusPropertiesCopy.removeIf(e -> QUARKUS_IGNORED_PROPERTIES.contains(e.getKey().toString()));
 
         if (!quarkusPropertiesCopy.isEmpty()) {
             LOGGER.info(QuarkusExtensionUtil.getLogMessage("Quarkus properties have changed"));
@@ -173,10 +172,6 @@ final class QuarkusBuildCache {
         }
 
         return false;
-    }
-
-    private List<String> getIgnoredProperties(List<String> dumpConfigIgnoredProperties) {
-        return Stream.concat(QUARKUS_IGNORED_PROPERTIES.stream(), dumpConfigIgnoredProperties.stream()).collect(Collectors.toList());
     }
 
     private boolean isNativeBuild(Properties quarkusCurrentProperties) {

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
@@ -2,6 +2,8 @@ package com.gradle;
 
 import org.apache.maven.project.MavenProject;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 final class QuarkusExtensionConfiguration {
@@ -30,6 +32,12 @@ final class QuarkusExtensionConfiguration {
     // Default dump config file suffix
     private static final String DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_SUFFIX = "config-dump";
 
+    // Extra output dirs key
+    private static final String DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS = "DEVELOCITY_QUARKUS_EXTRA_OUTPUT_DIRS";
+
+    // Extra output files key
+    private static final String DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES = "DEVELOCITY_QUARKUS_EXTRA_OUTPUT_FILES";
+
     private final Properties configuration = new Properties();
 
     QuarkusExtensionConfiguration(MavenProject project) {
@@ -52,6 +60,8 @@ final class QuarkusExtensionConfiguration {
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_PREFIX, DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_PREFIX);
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_SUFFIX, DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_SUFFIX);
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_CONFIG_FILE, "");
+        configuration.setProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS, "");
+        configuration.setProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES, "");
     }
 
     private void overrideFromEnvironment() {
@@ -139,6 +149,21 @@ final class QuarkusExtensionConfiguration {
                 configuration.getProperty(DEVELOCITY_QUARKUS_KEY_BUILD_PROFILE)
         );
     }
+
+    /**
+     * @return extra goal output directories to cache
+     */
+    List<String> getExtraOutputDirs() {
+        return Arrays.asList(configuration.getProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS).split(","));
+    }
+
+    /**
+     * @return extra goal output files to cache
+     */
+    List<String> getExtraOutputFiles() {
+        return Arrays.asList(configuration.getProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES).split(","));
+    }
+
 
     @Override
     public String toString() {

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
@@ -2,8 +2,6 @@ package com.gradle;
 
 import org.apache.maven.project.MavenProject;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 
 final class QuarkusExtensionConfiguration {
@@ -32,9 +30,6 @@ final class QuarkusExtensionConfiguration {
     // Default dump config file suffix
     private static final String DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_SUFFIX = "config-dump";
 
-    // Dump config ignored properties key
-    private static final String DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_IGNORED_PROPERTIES = "DEVELOCITY_QUARKUS_DUMP_IGNORED_PROPERTIES";
-
     private final Properties configuration = new Properties();
 
     QuarkusExtensionConfiguration(MavenProject project) {
@@ -56,7 +51,6 @@ final class QuarkusExtensionConfiguration {
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_BUILD_PROFILE, DEVELOCITY_QUARKUS_DEFAULT_BUILD_PROFILE);
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_PREFIX, DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_PREFIX);
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_SUFFIX, DEVELOCITY_QUARKUS_DEFAULT_DUMP_CONFIG_SUFFIX);
-        configuration.setProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_IGNORED_PROPERTIES, "");
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_CONFIG_FILE, "");
     }
 
@@ -144,13 +138,6 @@ final class QuarkusExtensionConfiguration {
                 configuration.getProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_PREFIX),
                 configuration.getProperty(DEVELOCITY_QUARKUS_KEY_BUILD_PROFILE)
         );
-    }
-
-    /**
-     * @return list of properties to ignore when comparing config dump and current config
-     */
-    List<String> getDumpConfigIgnoredProperties() {
-        return Arrays.asList(configuration.getProperty(DEVELOCITY_QUARKUS_KEY_DUMP_CONFIG_IGNORED_PROPERTIES).split(","));
     }
 
     @Override

--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusExtensionConfiguration.java
@@ -38,6 +38,9 @@ final class QuarkusExtensionConfiguration {
     // Extra output files key
     private static final String DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES = "DEVELOCITY_QUARKUS_EXTRA_OUTPUT_FILES";
 
+    // Native build in container required key
+    private static final String DEVELOCITY_QUARKUS_KEY_NATIVE_BUILD_IN_CONTAINER_REQUIRED = "DEVELOCITY_QUARKUS_NATIVE_BUILD_IN_CONTAINER_REQUIRED";
+
     private final Properties configuration = new Properties();
 
     QuarkusExtensionConfiguration(MavenProject project) {
@@ -62,6 +65,7 @@ final class QuarkusExtensionConfiguration {
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_CONFIG_FILE, "");
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_DIRS, "");
         configuration.setProperty(DEVELOCITY_QUARKUS_KEY_EXTRA_OUTPUT_FILES, "");
+        configuration.setProperty(DEVELOCITY_QUARKUS_KEY_NATIVE_BUILD_IN_CONTAINER_REQUIRED, Boolean.TRUE.toString());
     }
 
     private void overrideFromEnvironment() {
@@ -97,6 +101,13 @@ final class QuarkusExtensionConfiguration {
     boolean isQuarkusCacheEnabled() {
         // Quarkus cache is enabled by default
         return !Boolean.FALSE.toString().equals(configuration.get(DEVELOCITY_QUARKUS_KEY_CACHE_ENABLED));
+    }
+
+    /**
+     * @return whether native build requires in-container build strategy or not
+     */
+    boolean isNativeBuildInContainerRequired() {
+        return !Boolean.FALSE.toString().equals(configuration.get(DEVELOCITY_QUARKUS_KEY_NATIVE_BUILD_IN_CONTAINER_REQUIRED));
     }
 
     /**


### PR DESCRIPTION
- Allow to disable requirement for in-container strategy for native builds
- Allow to configure extra outputs
- Remove configuration dump property exclusion