### PR TITLE
Allow cross OS cache hits when using in-container build strategy

### DIFF
--- a/quarkus-build-caching-extension/README.md
+++ b/quarkus-build-caching-extension/README.md
@@ -254,8 +254,10 @@ This extension makes the Quarkus build goal cacheable by configuring the followi
 #### General inputs
 - The compilation classpath
 - Generated sources directory
-- OS details (name, version, arch)
 - JDK version
+
+#### Inputs specific to the non in-container build strategy
+- OS details (name, version, arch)
 
 #### Quarkus properties
 See [here](https://quarkus.io/guides/config-reference#configuration-sources) for details


### PR DESCRIPTION
Remove the OS characteristics as goal inputs when the in-container build strategy is configured.
This mimics the Java Compile goal configuration (OS details are not an input),