### PR TITLE
Build scan console log capturing is disabled when Gradle `properties` task is requested

### DIFF
--- a/convention-develocity-gradle-plugin/README.md
+++ b/convention-develocity-gradle-plugin/README.md
@@ -69,7 +69,7 @@ cd plugins/gradle-5-or-newer
 Once you have published the plugins, you can run the example builds under `examples`:
 
 ```bash
-cd examples/gradle_6_and_later
+cd examples/gradle_6.9_and_later
 ./gradlew build
 ```
 

--- a/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
+++ b/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
@@ -57,19 +57,18 @@ public class ConventionDevelocityGradlePlugin implements Plugin<Object> {
     private void configureDevelocity(DevelocityConfiguration develocity, StartParameter startParameter) {
         // CHANGE ME: Apply your Develocity configuration here
         develocity.getServer().set("https://develocity-samples.gradle.com");
-        if (!containsPropertiesTask(startParameter)) {
-            configureBuildScan(develocity.getBuildScan());
-        }
+        configureBuildScan(develocity.getBuildScan(), startParameter);
+    }
+
+    private void configureBuildScan(BuildScanConfiguration buildScan, StartParameter startParameter) {
+        // CHANGE ME: Apply your Build Scan configuration here
+        buildScan.getUploadInBackground().set(!isCi());
+        buildScan.getCapture().getBuildLogging().set(!containsPropertiesTask(startParameter));
     }
 
     private boolean containsPropertiesTask(StartParameter startParameter) {
         return startParameter.getTaskNames().contains("properties")
                 || startParameter.getTaskNames().stream().anyMatch(it -> it.endsWith(":properties"));
-    }
-
-    private void configureBuildScan(BuildScanConfiguration buildScan) {
-        // CHANGE ME: Apply your Build Scan configuration here
-        buildScan.getUploadInBackground().set(!isCi());
     }
 
     private void configureBuildCache(BuildCacheConfiguration buildCache, DevelocityConfiguration develocity) {

--- a/convention-develocity-shared/README.md
+++ b/convention-develocity-shared/README.md
@@ -122,7 +122,7 @@ cd examples/gradle_5
 cd examples/gradle_6
 ./gradlew build
 
-cd examples/gradle_6_and_later
+cd examples/gradle_6.9_and_later
 ./gradlew build
 ``` 
 

--- a/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
+++ b/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
@@ -3,7 +3,9 @@ package com.myorg;
 import com.gradle.CommonCustomUserDataGradlePlugin;
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration;
 import com.gradle.develocity.agent.gradle.DevelocityPlugin;
+import com.gradle.develocity.agent.gradle.scan.BuildScanConfiguration;
 import com.myorg.configurable.GradleDevelocityConfigurable;
+import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -42,6 +44,7 @@ final class ConventionDevelocityGradlePlugin implements Plugin<Object> {
         settings.getPluginManager().apply(CommonCustomUserDataGradlePlugin.class);
         DevelocityConfiguration develocity = settings.getExtensions().getByType(DevelocityConfiguration.class);
         new DevelocityConventions().configureDevelocity(new GradleDevelocityConfigurable(develocity, settings.getBuildCache()));
+        configureBuildScan(develocity.getBuildScan(), settings.getGradle().getStartParameter());
     }
 
     private void configureGradle5(Project project) {
@@ -49,6 +52,16 @@ final class ConventionDevelocityGradlePlugin implements Plugin<Object> {
         project.getPluginManager().apply(CommonCustomUserDataGradlePlugin.class);
         DevelocityConfiguration develocity = project.getExtensions().getByType(DevelocityConfiguration.class);
         new DevelocityConventions().configureDevelocity(new GradleDevelocityConfigurable(develocity));
+        configureBuildScan(develocity.getBuildScan(), project.getGradle().getStartParameter());
+    }
+
+    private void configureBuildScan(BuildScanConfiguration buildScan, StartParameter startParameter) {
+        buildScan.getCapture().getBuildLogging().set(!containsPropertiesTask(startParameter));
+    }
+
+    private boolean containsPropertiesTask(StartParameter startParameter) {
+        return startParameter.getTaskNames().contains("properties")
+                || startParameter.getTaskNames().stream().anyMatch(it -> it.endsWith(":properties"));
     }
 
     private static boolean isGradle6OrNewer() {


### PR DESCRIPTION
This PR updates the convention samples to disable console log capturing when the Gradle `properties` task is requested.

> [!IMPORTANT]  
> This introduces the concept of build tool-specific conventions in the shared sample. The common conventions are applied first, followed by the build tool-specific conventions.