### PR TITLE
Add support for Quarkus BuildMojo.attachSboms parameter

### DIFF
--- a/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
+++ b/quarkus-build-caching-extension/src/main/java/com/gradle/QuarkusBuildCache.java
@@ -267,7 +267,7 @@ final class QuarkusBuildCache {
         inputs
                 .fileSet("generatedSourcesDirectory", fileSet -> {
                 })
-                .properties("appArtifact", "closeBootstrappedApp", "finalName", "ignoredEntries", "manifestEntries", "manifestSections", "skip", "skipOriginalJarRename", "systemProperties", "properties")
+                .properties("appArtifact", "closeBootstrappedApp", "finalName", "ignoredEntries", "manifestEntries", "manifestSections", "skip", "skipOriginalJarRename", "systemProperties", "properties", "attachSboms")
                 .ignore("project", "buildDir", "mojoExecution", "session", "repoSession", "repos", "pluginRepos", "attachRunnerAsMainArtifact", "bootstrapId", "buildDirectory");
     }
 


### PR DESCRIPTION
### Issue
The integration tests against the latest Quarkus version are [failing](https://github.com/gradle/develocity-build-config-samples/actions/runs/10464543901/job/29014838799?pr=1369)

This is due to a [new parameter](https://github.com/quarkusio/quarkus/commit/342a88e2830eba14c958ddd4b48277445b30edf7#diff-784b0a28679cfd7486e574f42e90ece03e187bae1e132d5c408f72eaa7ecfdf0R79) introduced in Quarkus `BuildMojo`

### Fix
Declare the property as a goal input