### PR TITLE
Convention samples access environment in configuration cache compatible way

### DIFF
--- a/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/DevelocityConventions.java
+++ b/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/DevelocityConventions.java
@@ -3,8 +3,15 @@ package com.myorg;
 import com.myorg.configurable.BuildCacheConfigurable;
 import com.myorg.configurable.BuildScanConfigurable;
 import com.myorg.configurable.DevelocityConfigurable;
+import com.myorg.configurable.ExecutionContext;
 
 final class DevelocityConventions {
+
+    private final ExecutionContext context;
+
+    DevelocityConventions(ExecutionContext context) {
+        this.context = context;
+    }
 
     void configureDevelocity(DevelocityConfigurable develocity) {
         // CHANGE ME: Apply your Develocity configuration here
@@ -26,9 +33,9 @@ final class DevelocityConventions {
         buildCache.getRemote().setStoreEnabled(isCi());
     }
 
-    private static boolean isCi() {
+    private boolean isCi() {
         // CHANGE ME: Apply your environment detection logic here
-        return System.getenv().containsKey("CI");
+        return context.environmentVariable("CI").isPresent();
     }
 
 }

--- a/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/configurable/ExecutionContext.java
+++ b/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/configurable/ExecutionContext.java
@@ -1,0 +1,11 @@
+package com.myorg.configurable;
+
+import java.util.Optional;
+
+public interface ExecutionContext {
+
+    Optional<String> environmentVariable(String name);
+
+    Optional<String> systemProperty(String name);
+
+}

--- a/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
+++ b/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/ConventionDevelocityGradlePlugin.java
@@ -5,17 +5,28 @@ import com.gradle.develocity.agent.gradle.DevelocityConfiguration;
 import com.gradle.develocity.agent.gradle.DevelocityPlugin;
 import com.gradle.develocity.agent.gradle.scan.BuildScanConfiguration;
 import com.myorg.configurable.GradleDevelocityConfigurable;
+import com.myorg.configurable.GradleExecutionContext;
 import org.gradle.StartParameter;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.util.GradleVersion;
+
+import javax.inject.Inject;
 
 /**
  * An example Gradle plugin for enabling and configuring Develocity features
  */
 final class ConventionDevelocityGradlePlugin implements Plugin<Object> {
+
+    private final ProviderFactory providers;
+
+    @Inject
+    public ConventionDevelocityGradlePlugin(ProviderFactory providers) {
+        this.providers = providers;
+    }
 
     @Override
     public void apply(Object target) {
@@ -43,7 +54,8 @@ final class ConventionDevelocityGradlePlugin implements Plugin<Object> {
         settings.getPluginManager().apply(DevelocityPlugin.class);
         settings.getPluginManager().apply(CommonCustomUserDataGradlePlugin.class);
         DevelocityConfiguration develocity = settings.getExtensions().getByType(DevelocityConfiguration.class);
-        new DevelocityConventions().configureDevelocity(new GradleDevelocityConfigurable(develocity, settings.getBuildCache()));
+        GradleExecutionContext context = new GradleExecutionContext(providers);
+        new DevelocityConventions(context).configureDevelocity(new GradleDevelocityConfigurable(develocity, settings.getBuildCache()));
         configureBuildScan(develocity.getBuildScan(), settings.getGradle().getStartParameter());
     }
 
@@ -51,7 +63,8 @@ final class ConventionDevelocityGradlePlugin implements Plugin<Object> {
         project.getPluginManager().apply(DevelocityPlugin.class);
         project.getPluginManager().apply(CommonCustomUserDataGradlePlugin.class);
         DevelocityConfiguration develocity = project.getExtensions().getByType(DevelocityConfiguration.class);
-        new DevelocityConventions().configureDevelocity(new GradleDevelocityConfigurable(develocity));
+        GradleExecutionContext context = new GradleExecutionContext(providers);
+        new DevelocityConventions(context).configureDevelocity(new GradleDevelocityConfigurable(develocity));
         configureBuildScan(develocity.getBuildScan(), project.getGradle().getStartParameter());
     }
 

--- a/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/configurable/GradleExecutionContext.java
+++ b/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/configurable/GradleExecutionContext.java
@@ -1,0 +1,48 @@
+package com.myorg.configurable;
+
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.util.GradleVersion;
+
+import java.util.Optional;
+
+public final class GradleExecutionContext implements ExecutionContext {
+
+    private final ProviderFactory providers;
+
+    public GradleExecutionContext(ProviderFactory providers) {
+        this.providers = providers;
+    }
+
+    // Environment variables must be accessed differently in some Gradle
+    // versions in order to detect changes when configuration cache is enabled.
+    @Override
+    public Optional<String> environmentVariable(String name) {
+        if (isGradle65OrNewer() && !isGradle74OrNewer()) {
+            @SuppressWarnings("deprecation") Provider<String> variable = providers.environmentVariable(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(variable.getOrNull());
+        }
+        return Optional.ofNullable(System.getenv(name));
+    }
+
+    // System properties must be accessed differently in some Gradle
+    // versions in order to detect changes when configuration cache is enabled.
+    @Override
+    public Optional<String> systemProperty(String name) {
+        if (isGradle65OrNewer() && !isGradle74OrNewer()) {
+            @SuppressWarnings("deprecation") Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(property.getOrNull());
+        }
+        return Optional.ofNullable(System.getProperty(name));
+    }
+
+    private static boolean isGradle65OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("6.5")) >= 0;
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private static boolean isGradle74OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("7.4")) >= 0;
+    }
+
+}

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityMavenExtensionListener.java
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityMavenExtensionListener.java
@@ -3,6 +3,7 @@ package com.myorg;
 import com.gradle.develocity.agent.maven.api.DevelocityApi;
 import com.gradle.develocity.agent.maven.api.DevelocityListener;
 import com.myorg.configurable.MavenDevelocityConfigurable;
+import com.myorg.configurable.MavenExecutionContext;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.component.annotations.Component;
 
@@ -18,7 +19,8 @@ final class ConventionDevelocityMavenExtensionListener implements DevelocityList
 
     @Override
     public void configure(DevelocityApi develocity, MavenSession session) {
-        new DevelocityConventions().configureDevelocity(new MavenDevelocityConfigurable(develocity));
+        MavenExecutionContext context = new MavenExecutionContext();
+        new DevelocityConventions(context).configureDevelocity(new MavenDevelocityConfigurable(develocity));
     }
 
 }

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/configurable/MavenExecutionContext.java
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/configurable/MavenExecutionContext.java
@@ -1,0 +1,17 @@
+package com.myorg.configurable;
+
+import java.util.Optional;
+
+public final class MavenExecutionContext implements ExecutionContext {
+
+    @Override
+    public Optional<String> environmentVariable(String name) {
+        return Optional.ofNullable(System.getenv(name));
+    }
+
+    @Override
+    public Optional<String> systemProperty(String name) {
+        return Optional.ofNullable(System.getProperty(name));
+    }
+
+}


### PR DESCRIPTION
This changes the Gradle convention sample to read environment variables in such a way that changes are detected when configuration cache is enabled in all versions of Gradle.

The shared convention sample was also updated to abstract how environment variables (and system properties) are read between build tools and also have received the same configuration cache compatible changes for the Gradle plugin.

Currently, the only use case for reading environment variables is to know if the build is running in CI which will typically not change between build invocations under normal circumstances. However, users forking the sample may desire reading other environment variables or system properties that are more likely to change between build invocations, which is generally pretty common. To encourage using best practices and avoid having to explain the nuances of configuration cache behavior between Gradle versions _if_ they decide to extend the sample, it was determined the easiest path forward is to just implement it in the sample so it works out of the box.

This is [the same environment variable & system property logic used in CCUD](https://github.com/gradle/common-custom-user-data-gradle-plugin/blob/461581adcd86913a754d09c57c80f8875f93ea42/src/main/java/com/gradle/Utils.java#L49-L54).