### PR TITLE
Maven listener isn't called in shared sample

### DIFF
--- a/.github/workflows/convention-develocity-shared-verification.yml
+++ b/.github/workflows/convention-develocity-shared-verification.yml
@@ -23,6 +23,9 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+      - name: Configure Develocity Solutions instance
+        working-directory: convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg
+        run: sed -i 's/develocity-samples.gradle.com/ge.solutions-team.gradle.com/g' DevelocityConventions.java
       - name: Build with Gradle
         working-directory: convention-develocity-shared
         run: ./gradlew build publishToMavenLocal
@@ -77,7 +80,7 @@ jobs:
       - name: Verify example build
         id: build
         working-directory: convention-develocity-shared/examples/gradle_${{ matrix.versions.sample }}
-        run: ./gradlew build -Ddevelocity.url=https://ge.solutions-team.gradle.com
+        run: ./gradlew build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify Build Scan published
@@ -121,7 +124,7 @@ jobs:
       - name: Verify example build
         id: build
         working-directory: convention-develocity-shared/examples/maven_${{ matrix.versions.sample }}
-        run: ./mvnw clean verify -Ddevelocity.url=https://ge.solutions-team.gradle.com
+        run: ./mvnw clean verify
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify Build Scan published

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityMavenExtensionListener.java
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityMavenExtensionListener.java
@@ -5,16 +5,10 @@ import com.gradle.develocity.agent.maven.api.DevelocityListener;
 import com.myorg.configurable.MavenDevelocityConfigurable;
 import com.myorg.configurable.MavenExecutionContext;
 import org.apache.maven.execution.MavenSession;
-import org.codehaus.plexus.component.annotations.Component;
 
 /**
  * An example Maven extension for enabling and configuring Develocity features.
  */
-@Component(
-        role = DevelocityListener.class,
-        hint = "convention-develocity-maven-extension",
-        description = "Configures the Develocity Maven extension for com.myorg"
-)
 final class ConventionDevelocityMavenExtensionListener implements DevelocityListener {
 
     @Override

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/resources/META-INF/plexus/components.xml
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/resources/META-INF/plexus/components.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-set>
+    <components>
+        <component>
+            <role>com.gradle.develocity.agent.maven.api.DevelocityListener</role>
+            <role-hint>convention-develocity-maven-extension</role-hint>
+            <implementation>com.myorg.ConventionDevelocityMavenExtensionListener</implementation>
+            <description>Configures the Develocity Maven extension for com.myorg</description>
+            <isolated-realm>false</isolated-realm>
+        </component>
+    </components>
+</component-set>


### PR DESCRIPTION
This was missed when creating the shared build. It meant the listener was never called. I never encountered it because I always ran with `-Ddevelocity.url=https://ge.solutions-team.gradle.com`. 