### PR TITLE
Convention workflows are enhanced

### DIFF
--- a/.github/workflows/convention-develocity-gradle-plugin-verification.yml
+++ b/.github/workflows/convention-develocity-gradle-plugin-verification.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build with Gradle - Gradle 2 through 4
         working-directory: convention-develocity-gradle-plugin/plugins/gradle-2-through-4
         run: ./gradlew build
+      - name: Configure Develocity Solutions instance
+        working-directory: convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/src/main/java/com/myorg
+        run: sed -i 's/develocity-samples.gradle.com/ge.solutions-team.gradle.com/g' ConventionDevelocityGradlePlugin.java
       - name: Build with Gradle - Gradle 5 or newer
         working-directory: convention-develocity-gradle-plugin/plugins/gradle-5-or-newer
         run: ./gradlew build publishToMavenLocal
@@ -82,7 +85,7 @@ jobs:
       - name: Verify example build
         id: build
         working-directory: convention-develocity-gradle-plugin/examples/gradle_${{ matrix.versions.sample }}
-        run: ./gradlew build -Ddevelocity.url=https://ge.solutions-team.gradle.com
+        run: ./gradlew build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify Build Scan published

--- a/.github/workflows/convention-develocity-gradle-plugin-verification.yml
+++ b/.github/workflows/convention-develocity-gradle-plugin-verification.yml
@@ -59,7 +59,7 @@ jobs:
           - sample: '6.9_and_later'
             version: '8.0.2'
           - sample: '6.9_and_later'
-            version: '(Current)'
+            version: 'wrapper'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,22 +70,17 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: ${{ matrix.versions.version }}
       - name: Download plugin
         uses: actions/download-artifact@v4
         with:
           name: convention-develocity-gradle-plugin
           path: ~/.m2/repository/com/myorg
-      - name: Set Gradle version
-        if: ${{ matrix.versions.version != '(Current)' }}
-        working-directory: convention-develocity-gradle-plugin/examples/gradle_${{ matrix.versions.sample }}
-        run: |
-          sed -i '/distributionSha256Sum.*/d' gradle/wrapper/gradle-wrapper.properties
-          ./gradlew wrapper --gradle-version=${{ matrix.versions.version }} --no-scan
-          ./gradlew wrapper --gradle-version=${{ matrix.versions.version }} --no-scan
       - name: Verify example build
         id: build
         working-directory: convention-develocity-gradle-plugin/examples/gradle_${{ matrix.versions.sample }}
-        run: ./gradlew build
+        run: gradle build
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify Build Scan published

--- a/.github/workflows/convention-develocity-maven-extension-verification.yml
+++ b/.github/workflows/convention-develocity-maven-extension-verification.yml
@@ -22,6 +22,11 @@ jobs:
           java-version: '8'
           distribution: 'temurin'
           cache: maven
+      - name: Set up Maven
+        uses: gradle/develocity-actions/setup-maven@v1.2
+      - name: Configure Develocity Solutions instance
+        working-directory: convention-develocity-maven-extension/extension/src/main/java/com/myorg
+        run: sed -i 's/develocity-samples.gradle.com/ge.solutions-team.gradle.com/g' ConventionDevelocityListener.java
       - name: Build with Maven
         working-directory: convention-develocity-maven-extension/extension
         run: ./mvnw clean install
@@ -68,7 +73,7 @@ jobs:
       - name: Verify example build
         id: build
         working-directory: convention-develocity-maven-extension/examples/maven_${{ matrix.versions.sample }}
-        run: ./mvnw clean verify -Ddevelocity.url=https://ge.solutions-team.gradle.com
+        run: ./mvnw clean verify
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
       - name: Verify Build Scan published


### PR DESCRIPTION
This PR enhances the single-build convention workflows, `convention-develocity-gradle-plugin` and `convention-develocity-maven-extension`, with findings from working on the `convention-develocity-shared`.

Namely, removing `-Ddevelocity.url=https://ge.solutions-team.gradle.com` from the build tool invocation and instead replacing `develocity-samples.gradle.com` with `ge.solutions-team.gradle.com` in the corresponding class, just as a real user would do. See https://github.com/gradle/develocity-build-config-samples/pull/1394 and commit 7dda2b078b6c2df351fb771b07da2521e72574ab for more details.

Additionally, I applied one suggestion by @bigdaz to leverage the `setup-gradle` action to configure the Gradle version, rather than using the `wrapper` task. See commit 6800afe3bfa88b1e51ca7c0b1ccc7dfb306e1576 for more details.
