### PR TITLE
Convention sample demonstrates disabling test caching by default

### DIFF
--- a/convention-develocity-shared/README.md
+++ b/convention-develocity-shared/README.md
@@ -141,3 +141,19 @@ cd examples/maven_3
 #### Requirements
 
 To run the example builds, use Java 8 or higher.
+
+---
+
+Example scans showing test caching disabled by default:
+  - Gradle 5.0: https://ge.solutions-team.gradle.com/s/ml355gcshr2je/timeline?details=si6uhuz4tdufw
+  - Gradle 6.0.1: https://ge.solutions-team.gradle.com/s/fqm4bohx7oouy/timeline?details=si6uhuz4tdufw
+  - Gradle 8.11.1: https://ge.solutions-team.gradle.com/s/qpzccsbovorka/timeline?details=si6uhuz4tdufw
+  - Maven 3.9.9 (Surefire): https://ge.solutions-team.gradle.com/s/rfgck3uzv7zgq/timeline?details=dvp4sj4dsdhru
+  - Maven 3.9.9 (Failsafe): https://ge.solutions-team.gradle.com/s/rfgck3uzv7zgq/timeline?details=tg55nc6hywfxo
+
+Example scans showing test caching re-enabled:
+  - Gradle 5.0: https://ge.solutions-team.gradle.com/s/dk5j62ccwj4ci/timeline?details=si6uhuz4tdufw
+  - Gradle 6.0.1: https://ge.solutions-team.gradle.com/s/k7bo2hrplpdhy/timeline?details=si6uhuz4tdufw
+  - Gradle 8.11.1: https://ge.solutions-team.gradle.com/s/3e3orwlfc6wdk/timeline?details=si6uhuz4tdufw
+  - Maven 3.9.9 (Surefire): https://ge.solutions-team.gradle.com/s/k7et7vnf4tozo/timeline?details=dvp4sj4dsdhru
+  - Maven 3.9.9 (Failsafe): https://ge.solutions-team.gradle.com/s/k7et7vnf4tozo/timeline?details=tg55nc6hywfxo

--- a/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/DevelocityConventions.java
+++ b/convention-develocity-shared/convention-develocity-common/src/main/java/com/myorg/DevelocityConventions.java
@@ -7,6 +7,11 @@ import com.myorg.configurable.ExecutionContext;
 
 final class DevelocityConventions {
 
+    public static final String TEST_CACHING_DISABLED_REASON = "more information would be required to cache tests as " +
+            "they may verify integration with other systems and always need to rerun";
+
+    public static final String TEST_CACHING_PROPERTY_NAME = "enableTestCaching";
+
     private final ExecutionContext context;
 
     DevelocityConventions(ExecutionContext context) {

--- a/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/GradleUtils.java
+++ b/convention-develocity-shared/convention-develocity-gradle-plugin/src/main/java/com/myorg/GradleUtils.java
@@ -1,0 +1,69 @@
+package com.myorg;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.provider.Provider;
+import org.gradle.util.GradleVersion;
+
+import java.util.function.Supplier;
+
+final class GradleUtils {
+
+    private GradleUtils() {
+    }
+
+    static void configureAllProjects(Settings settings, Action<Project> action) {
+        if (isGradle88OrNewer()) {
+            settings.getGradle().getLifecycle().beforeProject(action::execute);
+        } else {
+            settings.getGradle().allprojects(action);
+        }
+    }
+
+    static void configureAllProjects(Project project, Action<Project> action) {
+        project.allprojects(action);
+    }
+
+    static <T extends Task> void doNotCacheTaskIf(Project project, Class<T> taskType, String reason, Supplier<Boolean> doNotCacheIf) {
+        project.getTasks().withType(taskType).configureEach(task -> task.getOutputs().doNotCacheIf(reason, spec -> doNotCacheIf.get()));
+    }
+
+    static Provider<String> getProperty(Project project, String propertyName) {
+        if (isGradle62OrNewer()) {
+            return project.getProviders().gradleProperty(propertyName);
+        } else {
+            return project.provider(() -> (String) project.getRootProject().findProperty(propertyName));
+        }
+    }
+
+    static Provider<Boolean> getBooleanProperty(Project project, String propertyName) {
+        if (isGradle56OrNewer()) {
+            return getProperty(project, propertyName).map(Boolean::parseBoolean).orElse(false);
+        } else {
+            return project.provider(() -> Boolean.parseBoolean((String) project.getRootProject().findProperty(propertyName)));
+        }
+    }
+
+    static boolean isGradle88OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("8.8")) >= 0;
+    }
+
+    static boolean isGradle62OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("6.2")) >= 0;
+    }
+
+    static boolean isGradle6OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0;
+    }
+
+    static boolean isGradle56OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("5.6")) >= 0;
+    }
+
+    static boolean isGradle5OrNewer() {
+        return GradleVersion.current().compareTo(GradleVersion.version("5.0")) >= 0;
+    }
+
+}

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityListener.java
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/ConventionDevelocityListener.java
@@ -6,6 +6,11 @@ import com.myorg.configurable.MavenDevelocityConfigurable;
 import com.myorg.configurable.MavenExecutionContext;
 import org.apache.maven.execution.MavenSession;
 
+import static com.myorg.DevelocityConventions.TEST_CACHING_DISABLED_REASON;
+import static com.myorg.DevelocityConventions.TEST_CACHING_PROPERTY_NAME;
+import static com.myorg.MavenUtils.doNotCachePluginIf;
+import static com.myorg.MavenUtils.getBooleanProperty;
+
 /**
  * An example Maven extension for enabling and configuring Develocity features.
  */
@@ -15,6 +20,17 @@ final class ConventionDevelocityListener implements DevelocityListener {
     public void configure(DevelocityApi develocity, MavenSession session) {
         MavenExecutionContext context = new MavenExecutionContext();
         new DevelocityConventions(context).configureDevelocity(new MavenDevelocityConfigurable(develocity));
+        configureBuildCacheDefaults(develocity);
+    }
+
+    private void configureBuildCacheDefaults(DevelocityApi develocity) {
+        disableTestCachingByDefault(develocity);
+    }
+
+    private void disableTestCachingByDefault(DevelocityApi develocity) {
+        boolean enableTestCaching = getBooleanProperty(TEST_CACHING_PROPERTY_NAME);
+        doNotCachePluginIf(develocity, "maven-failsafe-plugin", TEST_CACHING_DISABLED_REASON, () -> !enableTestCaching);
+        doNotCachePluginIf(develocity, "maven-surefire-plugin", TEST_CACHING_DISABLED_REASON, () -> !enableTestCaching);
     }
 
 }

--- a/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/MavenUtils.java
+++ b/convention-develocity-shared/convention-develocity-maven-extension/src/main/java/com/myorg/MavenUtils.java
@@ -1,0 +1,28 @@
+package com.myorg;
+
+import com.gradle.develocity.agent.maven.api.DevelocityApi;
+
+import java.util.function.Supplier;
+
+final class MavenUtils {
+
+    private MavenUtils() {
+    }
+
+    static void doNotCachePluginIf(DevelocityApi develocity, String artifactId, String reason, Supplier<Boolean> doNotCacheIf) {
+        if (doNotCacheIf.get()) {
+            develocity.getBuildCache().registerMojoMetadataProvider(context -> {
+                context.withPlugin(artifactId, () -> {
+                    context.outputs(outputs -> {
+                        outputs.notCacheableBecause(reason);
+                    });
+                });
+            });
+        }
+    }
+
+    static boolean getBooleanProperty(String propertyName) {
+        return Boolean.parseBoolean(System.getProperty(propertyName));
+    }
+
+}

--- a/convention-develocity-shared/examples/gradle_5/build.gradle.kts
+++ b/convention-develocity-shared/examples/gradle_5/build.gradle.kts
@@ -2,3 +2,15 @@ plugins {
     id("com.myorg.convention-develocity-gradle-plugin") version "1.0"
     id("java")
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/convention-develocity-shared/examples/gradle_5/src/test/java/example/ExampleTest.java
+++ b/convention-develocity-shared/examples/gradle_5/src/test/java/example/ExampleTest.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void testJoin() {
+    Assertions.assertEquals(1, 1);
+  }
+
+}

--- a/convention-develocity-shared/examples/gradle_6.9_and_later/build.gradle.kts
+++ b/convention-develocity-shared/examples/gradle_6.9_and_later/build.gradle.kts
@@ -1,3 +1,15 @@
 plugins {
     id("java")
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/convention-develocity-shared/examples/gradle_6.9_and_later/src/test/java/example/ExampleTest.java
+++ b/convention-develocity-shared/examples/gradle_6.9_and_later/src/test/java/example/ExampleTest.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void testJoin() {
+    Assertions.assertEquals(1, 1);
+  }
+
+}

--- a/convention-develocity-shared/examples/gradle_6/build.gradle.kts
+++ b/convention-develocity-shared/examples/gradle_6/build.gradle.kts
@@ -1,3 +1,15 @@
 plugins {
     id("java")
 }
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+}

--- a/convention-develocity-shared/examples/gradle_6/src/test/java/example/ExampleTest.java
+++ b/convention-develocity-shared/examples/gradle_6/src/test/java/example/ExampleTest.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void testJoin() {
+    Assertions.assertEquals(1, 1);
+  }
+
+}

--- a/convention-develocity-shared/examples/maven_3/pom.xml
+++ b/convention-develocity-shared/examples/maven_3/pom.xml
@@ -13,4 +13,34 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.2</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/convention-develocity-shared/examples/maven_3/src/integration-test/java/example/ExampleIntegrationTest.java
+++ b/convention-develocity-shared/examples/maven_3/src/integration-test/java/example/ExampleIntegrationTest.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExampleIntegrationTest {
+
+  @Test
+  public void testJoin() {
+    Assertions.assertEquals(1, 1);
+  }
+
+}

--- a/convention-develocity-shared/examples/maven_3/src/test/java/example/ExampleTest.java
+++ b/convention-develocity-shared/examples/maven_3/src/test/java/example/ExampleTest.java
@@ -1,0 +1,13 @@
+package example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class ExampleTest {
+
+  @Test
+  public void testJoin() {
+    Assertions.assertEquals(1, 1);
+  }
+
+}

--- a/convention-develocity-shared/test.sh
+++ b/convention-develocity-shared/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+./gradlew publishToMavenLocal
+
+(cd examples/gradle_5 && ./gradlew clean build --build-cache && ./gradlew clean build --build-cache)
+(cd examples/gradle_6 && ./gradlew clean build --build-cache && ./gradlew clean build --build-cache)
+(cd examples/gradle_6.9_and_later && \
+  ./gradlew clean build --build-cache --configuration-cache -Dorg.gradle.unsafe.isolated-projects=true && \
+  ./gradlew clean build --build-cache --configuration-cache -Dorg.gradle.unsafe.isolated-projects=true)
+
+(cd examples/maven_3 && ./mvnw clean verify && ./mvnw clean verify)
+
+(cd examples/gradle_5 && ./gradlew clean build --build-cache -PenableTestCaching=true && ./gradlew clean build --build-cache -PenableTestCaching=true)
+(cd examples/gradle_6 && ./gradlew clean build --build-cache -PenableTestCaching=true && ./gradlew clean build --build-cache -PenableTestCaching=true)
+(cd examples/gradle_6.9_and_later && \
+  ./gradlew clean build --build-cache -PenableTestCaching=true && \
+  ./gradlew clean build --build-cache -PenableTestCaching=true)
+
+(cd examples/maven_3 && ./mvnw clean verify -DenableTestCaching=true && ./mvnw clean verify -DenableTestCaching=true)


### PR DESCRIPTION
Draft because this is not intended to be merged upstream. It only exists so feedback can be provided.