### PR TITLE
Copy extension descriptor from Develocity extension

### DIFF
--- a/convention-develocity-shared/convention-develocity-maven-extension/build.gradle.kts
+++ b/convention-develocity-shared/convention-develocity-maven-extension/build.gradle.kts
@@ -23,3 +23,9 @@ publishing {
         }
     }
 }
+
+tasks.jar.configure {
+    from(zipTree(configurations.compileClasspath.get().first { it.name.contains("develocity-maven-extension") })) {
+        include("META-INF/maven/extension.xml")
+    }
+}

--- a/convention-develocity-shared/convention-develocity-maven-extension/build.gradle.kts
+++ b/convention-develocity-shared/convention-develocity-maven-extension/build.gradle.kts
@@ -24,8 +24,8 @@ publishing {
     }
 }
 
-tasks.jar.configure {
-    from(zipTree(configurations.compileClasspath.get().first { it.name.contains("develocity-maven-extension") })) {
+tasks.jar {
+    from(zipTree(configurations.compileClasspath.map { it.files.first { jar -> jar.name.contains("develocity-maven-extension") }})) {
         include("META-INF/maven/extension.xml")
     }
 }


### PR DESCRIPTION
### Issue
When invoking a goal transitively provided by the original Develocity Maven extension, there is an error if the shared convention extension is applied

```
> mvn com.gradle:develocity-maven-extension:1.22.2:provision-access-key
[WARNING] Error injecting: com.gradle.maven.mojo.ProvisionDevelocityAccessKeyMojo
com.google.inject.ProvisionException: Unable to provision, see the following errors:

1) [Guice/NullInjectedIntoNonNullable]: null returned by binding at LocatorWiring
 but the 1st parameter provisioner of ProvisionDevelocityAccessKeyMojo.<init>(SourceFile:19) is not @Nullable
  at LocatorWiring
  at ProvisionDevelocityAccessKeyMojo.<init>(SourceFile:19)
      \_ for 1st parameter provisioner
  while locating ProvisionDevelocityAccessKeyMojo
```

### Fix
Add the [Maven plugin descriptor](https://maven.apache.org/ref/3.9.7/maven-core/extension.html) from the original Develocity extension to the shared convention extension