### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Set up Yarn
         run: npm install -g yarn
       - name: Download latest version of the Develocity Build Validation Scripts
-        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
+        uses: gradle/develocity-build-validation-scripts/.github/actions/maven/download@actions-stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run experiment 1
-        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable
+        uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-1@actions-stable
         with:
           gitRepo: ${{ github.server_url }}/${{ github.repository }}
           gitCommitId: ${{ github.sha }}
@@ -48,7 +48,7 @@ jobs:
           args: ${{ env.ARGS }}
           failIfNotFullyCacheable: true
       - name: Run experiment 2
-        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
+        uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-2@actions-stable
         with:
           gitRepo: ${{ github.server_url }}/${{ github.repository }}
           gitCommitId: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visit our website to learn more about [Develocity][develocity].
 The Develocity build configuration samples are open-source software released under the [Apache 2.0 License][apache-license].
 
 [develocity-build-config-samples]: https://github.com/gradle/develocity-build-config-samples
-[develocity-build-validation-scripts]: https://github.com/gradle/gradle-enterprise-build-validation-scripts
+[develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [ccud-gradle-plugin]: https://github.com/gradle/common-custom-user-data-gradle-plugin
 [ccud-maven-extension]: https://github.com/gradle/common-custom-user-data-maven-extension


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts