### PR TITLE
Enable configuration cache in all samples

### DIFF
--- a/common-develocity-gradle-configuration-kotlin/gradle.properties
+++ b/common-develocity-gradle-configuration-kotlin/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.vfs.watch=true
 org.gradle.daemon=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.parallel=true
 
 # adjust the locale values to your project's needs and the memory settings to the requirements of your build

--- a/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/gradle.properties
+++ b/convention-develocity-gradle-plugin/plugins/gradle-2-through-4/gradle.properties
@@ -1,10 +1,8 @@
-# enable these performance features unless you have specific reasons not to
 org.gradle.vfs.watch=true
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 
-# adjust the locale values to your project's needs and the memory settings to the requirements of your build
 # due to https://github.com/gradle/gradle/issues/19750 be sure to include both `-Xmx` and `-XX:MaxMetaspaceSize` settings
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx512m -XX:MaxMetaspaceSize=256m

--- a/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/gradle.properties
+++ b/convention-develocity-gradle-plugin/plugins/gradle-5-or-newer/gradle.properties
@@ -1,10 +1,8 @@
-# enable these performance features unless you have specific reasons not to
 org.gradle.vfs.watch=true
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 org.gradle.parallel=true
 
-# adjust the locale values to your project's needs and the memory settings to the requirements of your build
 # due to https://github.com/gradle/gradle/issues/19750 be sure to include both `-Xmx` and `-XX:MaxMetaspaceSize` settings
 org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx512m -XX:MaxMetaspaceSize=256m

--- a/convention-develocity-shared/gradle.properties
+++ b/convention-develocity-shared/gradle.properties
@@ -1,3 +1,12 @@
+org.gradle.vfs.watch=true
+org.gradle.daemon=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.parallel=true
+
+# due to https://github.com/gradle/gradle/issues/19750 be sure to include both `-Xmx` and `-XX:MaxMetaspaceSize` settings
+org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx512m -XX:MaxMetaspaceSize=256m
+
 # CHANGE ME: change to your organization's group ID
 group=com.myorg
 version=1.0


### PR DESCRIPTION
As of Gradle 9.0.0, running with configuration cache is now the preferred mode of execution. By enabling configuration cache, we will no longer see the console warning.