### PR TITLE
Fixed the Slack reporting for Gradle capturing samples nightly verification

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification-nightly.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification-nightly.yml
@@ -15,6 +15,7 @@ jobs:
     name: Verification of sample ${{ matrix.name }} with Gradle ${{ matrix.gradle-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         gradle-version: [ 'current', 'release-candidate', 'nightly' ]
         java-version: [ '21' ]
@@ -76,20 +77,18 @@ jobs:
     steps:
       - name: Get secrets
         uses: gradle/actions-internal/get-aws-secrets@v1
-        if: ${{ failure() }}
         with:
           role-to-assume: arn:aws:iam::992382829881:role/GHASecrets_develocity-build-config-samples_all
           secret-ids: |
             DV_SOLUTIONS_SCHEDULED_WORKFLOWS_WEBHOOK_URL,gha/develocity-build-config-samples/_all/dv_solutions_scheduled_workflows_webhook_url
       - name: Report scheduled workflow failure
         uses: slackapi/slack-github-action@v2.1.1
-        if: ${{ failure() }}
         with:
           webhook: ${{ env.DV_SOLUTIONS_SCHEDULED_WORKFLOWS_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           payload-templated: true
           payload: |
             {
-              "workflow_name": "Verify Gradle Data Capturing Samples (Nightly)",
+              "workflow_name": "DV Samples: Verify Gradle Data Capturing Samples (Nightly)",
               "workflow_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }

--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -14,6 +14,7 @@ jobs:
     name: Verification of ${{ matrix.name }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: 'Git diffs'


### PR DESCRIPTION
Fixed the Slack reporting for Gradle capturing samples nightly verification. 
Also made the matrix for the regular and nightly gradle samples not fail fast to be able to see if all the samples fail or just some (in one run).

The steps also required `failure()`, which means they never executed, as steps inside the job didn't fail, the previous job did (caught on the job level).