### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/convention-develocity-shared-verification.yml
+++ b/.github/workflows/convention-develocity-shared-verification.yml
@@ -9,6 +9,9 @@ on:
     paths: [ 'convention-develocity-shared/**', '.github/workflows/**' ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Convention Develocity Shared


### PR DESCRIPTION
Potential fix for [https://github.com/gradle/develocity-build-config-samples/security/code-scanning/20](https://github.com/gradle/develocity-build-config-samples/security/code-scanning/20)

To address the issue, add an explicit `permissions` block at the top level of the workflow (most maintainable), or to each job if finer control is needed. In this case, a single top-level block suffices and will apply to all jobs unless specifically overridden.  
This should be added after the workflow `name` and `on:` sections and before `jobs:`.  
The permission granted should be the minimal required — here, `contents: read`.  
No imports or definitions are needed outside the workflow YAML. No changes to actual build steps are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
