### PR TITLE
Declare workflow permissions explicitly

### DIFF
--- a/.github/workflows/convention-develocity-gradle-plugin-verification.yml
+++ b/.github/workflows/convention-develocity-gradle-plugin-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Convention Develocity Gradle Plugin
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/convention-develocity-maven-extension-verification.yml
+++ b/.github/workflows/convention-develocity-maven-extension-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Convention Develocity Maven Extension
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/convention-develocity-shared-verification.yml
+++ b/.github/workflows/convention-develocity-shared-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Convention Develocity Shared
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Gradle Data Capturing Samples
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Maven Build Caching Samples
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -1,5 +1,8 @@
 name: Verify Maven Data Capturing Samples
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/shell-script-validation.yml
+++ b/.github/workflows/shell-script-validation.yml
@@ -1,5 +1,8 @@
 name: Validate Shell Scripts
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Close CodeQL warnings, such as [this][1]

[1]: https://github.com/gradle/develocity-build-config-samples/security/code-scanning/21