### PR TITLE
Add namespace to extensions.xml files

### DIFF
--- a/build-caching-maven-samples/.mvn/extensions.xml
+++ b/build-caching-maven-samples/.mvn/extensions.xml
@@ -1,4 +1,4 @@
-<extensions>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>develocity-maven-extension</artifactId>

--- a/common-develocity-maven-configuration/.mvn/extensions.xml
+++ b/common-develocity-maven-configuration/.mvn/extensions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extensions>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>

--- a/convention-develocity-maven-extension/examples/maven_3/.mvn/extensions.xml
+++ b/convention-develocity-maven-extension/examples/maven_3/.mvn/extensions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extensions>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
     <extension>
         <groupId>com.myorg</groupId>
         <artifactId>convention-develocity-maven-extension</artifactId>

--- a/convention-develocity-shared/examples/maven_3/.mvn/extensions.xml
+++ b/convention-develocity-shared/examples/maven_3/.mvn/extensions.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<extensions>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
     <extension>
         <groupId>com.myorg</groupId>
         <artifactId>convention-develocity-maven-extension</artifactId>

--- a/rollout-maven-extension/.mvn/extensions.xml
+++ b/rollout-maven-extension/.mvn/extensions.xml
@@ -3,7 +3,7 @@
 <!-- The content of this configuration file needs to be adjusted to the specific needs of
      the entity rolling out Develocity to multiple Maven projects. -->
 
-<extensions>
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.1.0 https://maven.apache.org/xsd/core-extensions-1.1.0.xsd">
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>develocity-maven-extension</artifactId>


### PR DESCRIPTION
Relevant to make Renovate parsing of artifacts referenced in extensions.xml files work properly. Also a best practice.

Renovate only extracts dependencies from extensions.xml files declaring one of the expected and supported XML namespaces ([source][1]). 

[1]: https://github.com/renovatebot/renovate/blob/cc08ce00a300de031ffbdb2a51a1df765749aefa/lib/modules/manager/maven/extract.ts#L74