### PR TITLE
Add Renovate managers for Maven versions in shell scripts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,6 +35,29 @@
       ],
       "depNameTemplate": "com.gradle:common-custom-user-data-maven-extension",
       "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "custom-maven-distribution/create-custom-maven-distribution\\.sh",
+        "custom-maven-wrapper/create-custom-maven-wrapper\\.sh"
+      ],
+      "matchStrings": [
+        "maven_version=(?<currentValue>\\d+\\.\\d+(\\.\\d+)?)"
+      ],
+      "depNameTemplate": "org.apache.maven:apache-maven",
+      "datasourceTemplate": "maven"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "custom-maven-wrapper/create-custom-maven-wrapper\\.sh"
+      ],
+      "matchStrings": [
+        "org\\.apache\\.maven\\.plugins:maven-wrapper-plugin:(?<currentValue>\\d+\\.\\d+(\\.\\d+)?):wrapper"
+      ],
+      "depNameTemplate": "org.apache.maven.plugins:maven-wrapper-plugin",
+      "datasourceTemplate": "maven"
     }
   ],
   "packageRules": [
@@ -54,7 +77,9 @@
       "matchManagers": ["regex"],
       "matchPackageNames": [
         "com.gradle:develocity-maven-extension",
-        "com.gradle:common-custom-user-data-maven-extension"
+        "com.gradle:common-custom-user-data-maven-extension",
+        "org.apache.maven:apache-maven",
+        "org.apache.maven.plugins:maven-wrapper-plugin"
       ],
       "groupName": "Maven dependencies"
     },

--- a/custom-maven-wrapper/create-custom-maven-wrapper.sh
+++ b/custom-maven-wrapper/create-custom-maven-wrapper.sh
@@ -24,7 +24,7 @@ then
 fi
 
 echo -e "${yellow}Installing Maven wrapper${nc}"
-mvn -N io.takari:maven:0.7.7:wrapper -Dmaven=$maven_version
+mvn -N org.apache.maven.plugins:maven-wrapper-plugin:3.3.4:wrapper -Dmaven=$maven_version
 
 echo -e "${yellow}Customizing Maven wrapper script by adding a custom 'Wrapper' tag${nc}"
 grep -q 'scan.tag.Wrapper' mvnw || sed -i '' $'s/^MAVEN_OPTS/&="-Dscan.tag.Wrapper $&"\\\n&/' mvnw


### PR DESCRIPTION
## Summary
- Add custom regex managers to track the `maven_version` variable in `custom-maven-distribution/create-custom-maven-distribution.sh` and `custom-maven-wrapper/create-custom-maven-wrapper.sh` (`org.apache.maven:apache-maven`)
- Migrate `custom-maven-wrapper` from the deprecated `io.takari:maven` wrapper plugin to the official `org.apache.maven.plugins:maven-wrapper-plugin`
- Add a Renovate regex manager for the Maven Wrapper Plugin version
- Group both new dependencies into the existing "Maven dependencies" package rule