### PR TITLE
Ignore local/example packages in Renovate scanning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,6 +87,12 @@
       "matchFileNames": ["convention-develocity-gradle-plugin/plugins/gradle-2-through-4/**"],
       "matchPackageNames": ["com.gradle:build-scan-plugin"],
       "enabled": false
+    },
+    {
+      // Local/example packages that don't exist on Maven Central
+      "matchPackagePatterns": ["^com\\.myorg"],
+      "matchPackageNames": ["com.gradle:aspectj-parent"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds a `packageRules` entry to `.github/renovate.json5` that disables Renovate for local/example packages that don't exist on Maven Central
- Matches all `com.myorg` packages via pattern and `com.gradle:aspectj-parent` by exact name
- Fixes warnings on both `renovate/maven-dependencies` and `renovate/gradle-dependencies` branches