### PR TITLE
Roll back spring-cloud-contract to 5.0.2 to fix Maven build caching verification

### DIFF
--- a/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
+++ b/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-contract-verifier</artifactId>
-      <version>5.0.3</version>
+      <version>5.0.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -24,7 +24,7 @@
       <plugin>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-contract-maven-plugin</artifactId>
-        <version>5.0.3</version>
+        <version>5.0.2</version>
         <extensions>true</extensions>
         <configuration></configuration>
       </plugin>


### PR DESCRIPTION
## Problem

PR #2271 bumped `spring-cloud-contract` 5.0.2 → 5.0.3, which broke the **Verify Maven Build Caching Samples** check on `main` ([failing run](https://github.com/gradle/develocity-build-config-samples/actions/runs/27404959515)):

```
class org.apache.http.impl.client.BasicAuthCache cannot be cast to
class org.apache.http.client.AuthCache (... different Plexus ClassRealms)
```

The build-validation experiment runs the reactor twice; the first (cold) build fails at the root pom with 0 goals, while the warm second build passes — a classloader race.

## Root cause

Both `org.apache.http.client.AuthCache` and `...impl.client.BasicAuthCache` exist only inside `develocity-maven-extension-2.4.1.jar` (the extension shades httpclient without relocating the `org.apache.http` package). `spring-cloud-contract-maven-plugin` is declared `extensions=true`, and its **5.0.3** extension realm triggers a second load of the Develocity extension's `org.apache.http.*` classes into that realm — so two incompatible copies exist across ClassRealms and the cast fails during extension/session setup. **5.0.2** does not trigger this second load.

## Fix

Roll back only the `spring-cloud-contract` version (verifier dependency + the `extensions=true` plugin) to 5.0.2, keeping the other #2271 bumps (protobuf, spotbugs, spring-boot-logging), which are unaffected.

## Verification

Reproduced and verified locally with `mvn validate -pl spring-cloud-contract-project`:

- **5.0.3** → `BUILD FAILURE` (`BasicAuthCache cannot be cast to AuthCache`)
- **5.0.2** → `BUILD SUCCESS`, zero cast errors

## Follow-up

`develocity-maven-extension` 2.4.1 is already the latest, so there is no clean repo-side fix to keep 5.0.3. Consider a Renovate ignore for `spring-cloud-contract` and/or an upstream Develocity Maven extension report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)