### PR TITLE
Exclude sbt 2.x from Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -92,6 +92,12 @@
       "groupName": "sbt dependencies"
     },
     {
+      // The samples do not support sbt 2.x; stay on the 1.x line.
+      "matchManagers": ["sbt"],
+      "matchPackageNames": ["sbt/sbt"],
+      "allowedVersions": "<2.0.0"
+    },
+    {
       "matchManagers": ["gradle-wrapper"],
       "matchPaths": [
         "convention-develocity-gradle-plugin/examples/gradle_3_and_earlier/**",


### PR DESCRIPTION
Renovate proposed the sbt 2.x bump in #2276, which the samples don't support. This pins the `sbt/sbt` package to `<2.0.0` so Renovate stays on the 1.x line and stops proposing the major bump.