### PR TITLE
Skip spring-cloud-contract 5.0.3 in Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,6 +98,17 @@
       "allowedVersions": "<2.0.0"
     },
     {
+      // spring-cloud-contract 5.0.3 breaks Maven build-caching verification
+      // (HttpClient AuthCache ClassRealm conflict); bumped in #2271, rolled back
+      // in #2272. Floor at 5.0.4 to skip the broken 5.0.3; 5.0.4+ allowed when released.
+      "matchManagers": ["maven"],
+      "matchPackageNames": [
+        "org.springframework.cloud:spring-cloud-starter-contract-verifier",
+        "org.springframework.cloud:spring-cloud-contract-maven-plugin"
+      ],
+      "allowedVersions": "[5.0.4,)"
+    },
+    {
       "matchManagers": ["gradle-wrapper"],
       "matchPaths": [
         "convention-develocity-gradle-plugin/examples/gradle_3_and_earlier/**",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -98,15 +98,13 @@
       "allowedVersions": "<2.0.0"
     },
     {
-      // spring-cloud-contract 5.0.3 breaks Maven build-caching verification
-      // (HttpClient AuthCache ClassRealm conflict); bumped in #2271, rolled back
-      // in #2272. Floor at 5.0.4 to skip the broken 5.0.3; 5.0.4+ allowed when released.
+      // maven-resolver-transport-http 1.9.26/1.9.27 has a ClassRealm AuthCache bug
+      // (apache/maven-resolver#1919) that breaks the spring-cloud-contract extension
+      // realm in the build-caching verification. Pinned to 1.9.25 in that plugin's
+      // pom; skip the broken versions here and auto-bump to 1.9.28 when it ships.
       "matchManagers": ["maven"],
-      "matchPackageNames": [
-        "org.springframework.cloud:spring-cloud-starter-contract-verifier",
-        "org.springframework.cloud:spring-cloud-contract-maven-plugin"
-      ],
-      "allowedVersions": "[5.0.4,)"
+      "matchPackageNames": ["org.apache.maven.resolver:maven-resolver-transport-http"],
+      "allowedVersions": "!/^1\\.9\\.(26|27)$/"
     },
     {
       "matchManagers": ["gradle-wrapper"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -100,8 +100,10 @@
     {
       // maven-resolver-transport-http 1.9.26/1.9.27 has a ClassRealm AuthCache bug
       // (apache/maven-resolver#1919) that breaks the spring-cloud-contract extension
-      // realm in the build-caching verification. Pinned to 1.9.25 in that plugin's
-      // pom; skip the broken versions here and auto-bump to 1.9.28 when it ships.
+      // realm in the build-caching verification, so it is pinned to 1.9.25 in that
+      // plugin's pom. The fix is in 1.9.28: this rule skips the broken versions and
+      // lets the pin auto-bump to 1.9.28. Remove this rule and the pom pin once
+      // 1.9.28 is released.
       "matchManagers": ["maven"],
       "matchPackageNames": ["org.apache.maven.resolver:maven-resolver-transport-http"],
       "allowedVersions": "!/^1\\.9\\.(26|27)$/"

--- a/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
+++ b/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
@@ -14,7 +14,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-contract-verifier</artifactId>
-      <version>5.0.2</version>
+      <version>5.0.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -24,9 +24,16 @@
       <plugin>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-contract-maven-plugin</artifactId>
-        <version>5.0.2</version>
+        <version>5.0.3</version>
         <extensions>true</extensions>
         <configuration></configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-transport-http</artifactId>
+            <version>1.9.25</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <!-- When resolving from cache, need to explicitly register generated test sources -->
       <plugin>

--- a/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
+++ b/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
@@ -27,6 +27,13 @@
         <version>5.0.3</version>
         <extensions>true</extensions>
         <configuration></configuration>
+        <!--
+          maven-resolver-transport-http 1.9.26/1.9.27 has a ClassRealm AuthCache bug
+          (apache/maven-resolver#1919) that breaks build-caching verification when
+          spring-cloud-contract loads it in its extensions=true realm. The fix is in
+          1.9.28. Remove this whole <dependencies> block once 1.9.28 is released and
+          pulled in by spring-cloud-contract.
+        -->
         <dependencies>
           <dependency>
             <groupId>org.apache.maven.resolver</groupId>


### PR DESCRIPTION
5.0.3 breaks Maven build-caching verification (HttpClient `AuthCache` ClassRealm conflict). Bumped in #2271, rolled back in #2272, then re-proposed by Renovate in #2274.

`allowedVersions: [5.0.4,)` floors the version at 5.0.4 to skip 5.0.3; 5.0.4+ is allowed through when released.

Supersedes #2278 (auto-closed by GitHub after a force-push left its head with no common ancestor).