### PR TITLE
Document how to condition build cache push on credentials presence (fork PR support)

### DIFF
--- a/common-develocity-gradle-configuration-groovy/settings.gradle
+++ b/common-develocity-gradle-configuration-groovy/settings.gradle
@@ -4,6 +4,11 @@ plugins {
 }
 
 def isCI = System.getenv('CI') != null // adjust to your CI provider
+// If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
+// secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
+// In that case, also condition push on the access key being present (adjust the env var name):
+// def hasCredentials = System.getenv('DEVELOCITY_ACCESS_KEY') != null && !System.getenv('DEVELOCITY_ACCESS_KEY').isEmpty()
+
 
 develocity {
     server = 'https://develocity-samples.gradle.com' // adjust to your Develocity server

--- a/common-develocity-gradle-configuration-groovy/settings.gradle
+++ b/common-develocity-gradle-configuration-groovy/settings.gradle
@@ -4,11 +4,8 @@ plugins {
 }
 
 def isCI = System.getenv('CI') != null // adjust to your CI provider
-// If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
-// secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
-// In that case, also condition push on the access key being present (adjust the env var name):
+// If contributions happen through forked repository, also control access key presence
 // def hasCredentials = System.getenv('DEVELOCITY_ACCESS_KEY') != null && !System.getenv('DEVELOCITY_ACCESS_KEY').isEmpty()
-
 
 develocity {
     server = 'https://develocity-samples.gradle.com' // adjust to your Develocity server

--- a/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
+++ b/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
@@ -4,11 +4,8 @@ plugins {
 }
 
 val isCI = System.getenv("CI") != null // adjust to your CI provider
-// If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
-// secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
-// In that case, also condition isPush on the access key being present (adjust the env var name):
+// If contributions happen through forked repository, also control access key presence
 // val hasCredentials = !System.getenv("DEVELOCITY_ACCESS_KEY").isNullOrEmpty()
-
 
 develocity {
     server = "https://develocity-samples.gradle.com" // adjust to your Develocity server

--- a/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
+++ b/common-develocity-gradle-configuration-kotlin/settings.gradle.kts
@@ -4,6 +4,11 @@ plugins {
 }
 
 val isCI = System.getenv("CI") != null // adjust to your CI provider
+// If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
+// secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
+// In that case, also condition isPush on the access key being present (adjust the env var name):
+// val hasCredentials = !System.getenv("DEVELOCITY_ACCESS_KEY").isNullOrEmpty()
+
 
 develocity {
     server = "https://develocity-samples.gradle.com" // adjust to your Develocity server

--- a/common-develocity-maven-configuration/.mvn/develocity.xml
+++ b/common-develocity-maven-configuration/.mvn/develocity.xml
@@ -32,6 +32,11 @@
     <remote>
       <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled> <!-- adjust to your CI provider -->
+      <!-- If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
+           secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
+           In that case, also condition on the access key being present:
+      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled>
+           Adjust the env var name to match the one holding your Develocity access key. -->
     </remote>
   </buildCache>
 </develocity>

--- a/common-develocity-maven-configuration/.mvn/develocity.xml
+++ b/common-develocity-maven-configuration/.mvn/develocity.xml
@@ -32,11 +32,8 @@
     <remote>
       <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled> <!-- adjust to your CI provider -->
-      <!-- If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
-           secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
-           In that case, also condition on the access key being present:
-      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled>
-           Adjust the env var name to match the one holding your Develocity access key. -->
+      <!-- If contributions happen through forked repository, also control access key presence:
+      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled> -->
     </remote>
   </buildCache>
 </develocity>

--- a/rollout-maven-extension/.mvn/develocity.xml
+++ b/rollout-maven-extension/.mvn/develocity.xml
@@ -22,11 +22,8 @@
     <remote>
       <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
-      <!-- If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
-           secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
-           In that case, also condition on the access key being present:
-      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled>
-           Adjust the env var name to match the one holding your Develocity access key. -->
+      <!-- If contributions happen through forked repository, also control access key presence:
+      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled> -->
     </remote>
   </buildCache>
 </develocity>

--- a/rollout-maven-extension/.mvn/develocity.xml
+++ b/rollout-maven-extension/.mvn/develocity.xml
@@ -22,6 +22,11 @@
     <remote>
       <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['CI'])}</storeEnabled>
+      <!-- If your CI runs builds from forked repositories (e.g. GitHub Actions pull_request events),
+           secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.
+           In that case, also condition on the access key being present:
+      <storeEnabled>#{env['CI'] != null and env['DEVELOCITY_ACCESS_KEY'] != null and env['DEVELOCITY_ACCESS_KEY'] != ''}</storeEnabled>
+           Adjust the env var name to match the one holding your Develocity access key. -->
     </remote>
   </buildCache>
 </develocity>


### PR DESCRIPTION
When CI builds are triggered from forked repositories, secrets are not passed to the runner, causing cache store attempts to fail with HTTP 403.

This PR adds a commented-out alternative to the `storeEnabled` / `push` / `isPush` settings in all four sample configs, showing how to also condition on the access key being present for teams accepting contributions through forks.