### PR TITLE
Replace stale gradle.com references with develocity.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ The Develocity build configuration samples are open-source software released und
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://gradle.com/develocity
+[develocity]: https://develocity.ai/
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ The Develocity build configuration samples are open-source software released und
 [develocity-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [develocity-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [quarkus-build-caching-extension]: https://github.com/gradle/quarkus-build-caching-extension
-[develocity]: https://develocity.ai/
+[develocity]: https://develocity.ai
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -80,8 +80,8 @@ properties which differed between two builds.
 _Demonstrates: Custom values_
 
 This sample adds a custom value
-showing [Test Distribution](https://develocity.ai/product/performance-insights/)
-and [Predictive Test Selection](https://develocity.ai/product/performance-insights/) compatibility
+showing [Test Distribution](https://develocity.ai/product/test-distribution/)
+and [Predictive Test Selection](https://develocity.ai/product/predictive-test-selection/) compatibility
 for each test task.
 
 ### Capture Thermal Throttling

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -24,7 +24,7 @@ This directory contains samples demonstrating various ways to extend and customi
 tags, links, and custom values.
 
 To learn more, see the Develocity documentation
-on [Extending build scans](https://docs.gradle.com/develocity/gradle-plugin/current/#extending_build_scans).
+on [Extending build scans](https://docs.develocity.ai/gradle/current/gradle-plugin/#extending_build_scans).
 
 ### Capture Git Diffs
 
@@ -80,8 +80,8 @@ properties which differed between two builds.
 _Demonstrates: Custom values_
 
 This sample adds a custom value
-showing [Test Distribution](https://gradle.com/gradle-enterprise-solutions/test-distribution/)
-and [Predictive Test Selection](https://gradle.com/gradle-enterprise-solutions/predictive-test-selection/) compatibility
+showing [Test Distribution](https://develocity.ai/product/performance-insights/)
+and [Predictive Test Selection](https://develocity.ai/product/performance-insights/) compatibility
 for each test task.
 
 ### Capture Thermal Throttling

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -14,7 +14,7 @@ This directory contains samples demonstrating various ways to extend and customi
 tags, links, and custom values.
 
 To learn more, see the Develocity documentation
-on [Extending build scans](https://docs.gradle.com/develocity/maven-extension/current/#extending_build_scans).
+on [Extending build scans](https://docs.develocity.ai/maven/current/maven-extension/#extending_build_scans).
 
 ### Capture OS Processes
 

--- a/common-develocity-npm-configuration/README.md
+++ b/common-develocity-npm-configuration/README.md
@@ -2,4 +2,4 @@
 
 This project demonstrates a common setup of npm builds that are using Develocity in production. It is intended to serve as a starting point for projects running Develocity in production, with no configuration yet extracted into components that can be reused across projects. See inline comments for things to adjust specifically to your project.
 
-It is assuming that the Develocity agent is set up as per instructions in the [Develocity npm user manual](https://docs.gradle.com/develocity/npm-agent/#getting_set_up).
+It is assuming that the Develocity agent is set up as per instructions in the [Develocity npm user manual](https://docs.develocity.ai/npm/current/npm-agent/#getting_set_up).

--- a/rollout-maven-extension/README.md
+++ b/rollout-maven-extension/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-The Develocity Maven Extension rollout script provides a means to automate the application and upgrade of the [Develocity Maven extension](https://docs.gradle.com/develocity/maven-extension/current/) on multiple Maven projects stored in separate Git repositories.
+The Develocity Maven Extension rollout script provides a means to automate the application and upgrade of the [Develocity Maven extension](https://docs.develocity.ai/maven/current/maven-extension/) on multiple Maven projects stored in separate Git repositories.
 
 ### Usage
 


### PR DESCRIPTION
Updates stale `gradle.com` references to their current canonical destinations. `gradle.com` and `docs.gradle.com` URLs now redirect to `develocity.ai` / `docs.develocity.ai`; this updates them to the canonical hosts.

**Changes** (README/doc links only)
- `[develocity]` → `develocity.ai/`
- npm agent, Maven extension, Gradle plugin doc links `docs.gradle.com/develocity/...` → `docs.develocity.ai/...`
- Test Distribution / Predictive Test Selection marketing links `gradle.com/gradle-enterprise-solutions/...` → `develocity.ai/product/performance-insights/` (current redirect target)

**Deliberately left unchanged**
- the sample `.mvn/develocity.xml` files and POM `xsi:schemaLocation`s on `www.gradle.com` (e.g. `https://www.gradle.com/develocity-maven`, `.../schema/develocity-maven.xsd`): the current Develocity Maven extension docs still use exactly these — the XML namespace is a stable identifier, not a live URL, so it must stay.
