### PR TITLE
Bump spotbugs-maven-plugin to 4.10.4.0

### DIFF
--- a/build-caching-maven-samples/spotbugs-project/pom.xml
+++ b/build-caching-maven-samples/spotbugs-project/pom.xml
@@ -15,7 +15,7 @@
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
-        <version>4.10.3.0</version>
+        <version>4.10.4.0</version>
         <configuration>
           <effort>Max</effort>
           <threshold>Low</threshold>
@@ -69,7 +69,6 @@
 
                           <property><name>includeTests</name></property>
                           <property><name>addSourceDirs</name></property>
-                          <property><name>sourceEncoding</name></property>
                           <property><name>threshold</name></property>
                           <property><name>effort</name></property>
                           <property><name>relaxed</name></property>


### PR DESCRIPTION
Supersedes #2315, which bumps the version alone and fails the Verification check:

```
[ERROR] Failed to execute goal com.github.spotbugs:spotbugs-maven-plugin:4.10.4.0:spotbugs (spotbugs)
  on project spotbugs-project: The configuration for 'develocity-maven-extension' references
  'sourceEncoding', which is not found in class org.codehaus.mojo.spotbugs.SpotBugsMojo
```

4.10.4.0 removes the `sourceEncoding` parameter from the `spotbugs` goal ([spotbugs/spotbugs-maven-plugin#1495](https://github.com/spotbugs/spotbugs-maven-plugin/pull/1495)). Comparing the plugin descriptors from Maven Central, the `spotbugs` goal goes from `inputEncoding, outputEncoding, sourceEncoding` to `inputEncoding, outputEncoding`; no parameters were added, and the other goals are unchanged.

The two edits are atomic under `-Ddevelocity.cache.failOnUnhandledParameters=true`: referencing a parameter the mojo does not have fails the build, and so does leaving an existing parameter undeclared. Splitting them fails either way, which is why Renovate cannot land this update on its own.